### PR TITLE
:sparkles: Add retry and backoff, handle empty responses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 aiohttp==3.6.2
+backoff==1.10.0
 yarl==1.4.2

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     ],
     description="Asynchronous Python client for WLED.",
     include_package_data=True,
-    install_requires=["aiohttp>=3.0.0", "yarl"],
+    install_requires=["aiohttp>=3.0.0", "yarl", "backoff>=1.9.0"],
     keywords=["wled", "api", "async", "client"],
     license="MIT license",
     long_description_content_type="text/markdown",

--- a/wled/exceptions.py
+++ b/wled/exceptions.py
@@ -4,10 +4,14 @@
 class WLEDError(Exception):
     """Generic WLED exception."""
 
-    pass
+
+class WLEDEmptyResponseError(Exception):
+    """WLED empty API response exception."""
 
 
 class WLEDConnectionError(WLEDError):
     """WLED connection exception."""
 
-    pass
+
+class WLEDConnectionTimeoutError(WLEDConnectionError):
+    """WLED connection Timeout exception."""


### PR DESCRIPTION
There are multiple occasions a WLED device can respond in unexpected ways. Sometimes it is to busy with effects to respond or it spits out an empty response. Furthermore, WiFi issues at the user end may sometimes lead to timeouts. 

This PR adds:

- Retry logic in case a request or update failed
- Handling for empty responses
- Split our exceptions to be more specific

Goals of this PR is to ensure we retry a couple of times, before we start raising errors. This should cover the issues raised in:

https://github.com/home-assistant/core/issues/33921