### PR TITLE
✨ Adds support for on/bri on segments

### DIFF
--- a/wled/wled.py
+++ b/wled/wled.py
@@ -220,16 +220,14 @@ class WLED:
         if self._device is None:
             raise WLEDError("Unable to communicate with WLED to get the current state")
 
-        state = {
-            "bri": brightness,
-            "on": on,
-        }
-
+        state = {}
         segment = {
+            "bri": brightness,
             "cln": clones,
             "fx": effect,
             "ix": intensity,
             "len": length,
+            "on": on,
             "pal": palette,
             "rev": reverse,
             "sel": selected,
@@ -237,6 +235,18 @@ class WLED:
             "stop": stop,
             "sx": speed,
         }
+
+        # > WLED 0.10.0, does not support segment control on/bri.
+        # Luckily, the same release introduced si requests.
+        # Therefore, we can use that capability check to decide.
+        if not self._supports_si_request:
+            # This device does not support on/bri in the segment
+            del segment["on"]
+            del segment["bri"]
+            state = {
+                "bri": brightness,
+                "on": on,
+            }
 
         # Find effect if it was based on a name
         if effect is not None and isinstance(effect, str):


### PR DESCRIPTION
PR #84 implemented the support for detecting if the WLED device has support SI requests. This is helpful for the next feature, as it was introduced at the same time.

WLED 0.10.0 and newer have support for controlling the on/off state and brightness of each individual segment. Previously, those controls were applied to the strip as a whole by WLED.

This was implemented as a feature request by myself in:

- https://github.com/Aircoookie/WLED/issues/289
- https://github.com/Aircoookie/WLED/issues/290

However, this needed to be implemented in a way, we still would be able to support older devices as well. Since #84, we now know, since if the device supports SI requests, it is also supporting on/bri for segments 🎉 

