### PR TITLE
:hammer: Handle setting fx/pal by name case insensitive

### DIFF
--- a/wled/wled.py
+++ b/wled/wled.py
@@ -254,7 +254,7 @@ class WLED:
                 (
                     item.effect_id
                     for item in self._device.effects
-                    if item.name == effect
+                    if item.name.lower() == effect.lower()
                 ),
                 None,
             )
@@ -265,7 +265,7 @@ class WLED:
                 (
                     item.palette_id
                     for item in self._device.palettes
-                    if item.name == palette
+                    if item.name.lower() == palette.lower()
                 ),
             )
 


### PR DESCRIPTION
The WLED library allows you to set an effect or palette by name instead of ID. Which is really helpful in Home Assistant when writing automations.

However, they were case sensitive, which can be annoying. This is PR is addressing that.