### PR TITLE
🚑 Only backoff on a connection error

### DIFF
--- a/wled/wled.py
+++ b/wled/wled.py
@@ -60,7 +60,7 @@ class WLED:
         if self.base_path[-1] != "/":
             self.base_path += "/"
 
-    @backoff.on_exception(backoff.expo, WLEDError, max_tries=3)
+    @backoff.on_exception(backoff.expo, WLEDConnectionError, max_tries=3)
     async def _request(
         self,
         uri: str = "",


### PR DESCRIPTION
Only backoff in case of a connection error (no connection or timeout).
When the response is 400/500 ranges, there is no use to backoff.