### PR TITLE
:sparkles: - Add live override control

### DIFF
--- a/wled/wled.py
+++ b/wled/wled.py
@@ -340,6 +340,10 @@ class WLED:
         """Set a preset on a WLED device."""
         await self._request("state", method="POST", json_data={"ps": preset})
 
+    async def live(self, live: int) -> None:
+        """Set the live override status on a WLED device."""
+        await self._request("state", method="POST", json_data={"lor": live})
+
     async def playlist(self, playlist: int) -> None:
         """Set a running playlist on a WLED device."""
         await self._request("state", method="POST", json_data={"pl": playlist})


### PR DESCRIPTION
This adds a simple method to post the request needed to toggle live override (as from a UDP or E1.31 source).

I intend on also making a PR to the WLED integration for Home Assistant that will make this functionality available as a switch entity.