### PR TITLE
feat: add support for raw json request

### DIFF
--- a/tests/test_wled.py
+++ b/tests/test_wled.py
@@ -571,3 +571,15 @@ async def test_not_supporting_si_request_probing_based(aresponses):
         wled = WLED("example.com", session=session)
         await wled.update()
         assert not wled._supports_si_request
+
+
+@pytest.mark.asyncio
+async def test_raw_request(aresponses):
+    """Test for raw requests to WLED."""
+    aresponses.add(
+        "example.com", "/json/state", "POST", aresponses.Response(status=200, text="OK")
+    )
+
+    async with aiohttp.ClientSession() as session:
+        wled = WLED("example.com", session=session)
+        await wled.raw({"raw": "test"})

--- a/wled/wled.py
+++ b/wled/wled.py
@@ -344,6 +344,13 @@ class WLED:
         """Set a running playlist on a WLED device."""
         await self._request("state", method="POST", json_data={"pl": playlist})
 
+    async def raw(self, json_data: dict) -> None:
+        """Post a raw state request to WLED.
+
+        See https://github.com/Aircoookie/WLED/wiki/JSON-API
+        """
+        await self._request("state", method="POST", json_data=json_data)
+
     async def sync(
         self, *, send: Optional[bool] = None, receive: Optional[bool] = None
     ) -> None:


### PR DESCRIPTION
* useful to try out beta stuff for example playlists in HASS

Came across this while trying to activate the "preset cycle" functionality of WLED available in the UI.
Currently this can be activated in two ways:
- via `pl` object and additional fields. This is how it used in UI of WLED. Information is also available in the response from WLED. 
- via beta `playlist` API. But currently not API available to check if it is active or running. Would implement a solution as soon as this is out of beta and fully supported in the API. (https://github.com/Aircoookie/WLED/wiki/JSON-API#playlists)

For now i would try to use a raw function where the user can call a service in HASS and directly feed the required JSON to WLED.
