### PR TITLE
Added usermods to Info object

### DIFF
--- a/wled/models.py
+++ b/wled/models.py
@@ -203,6 +203,7 @@ class Info:
     version_id: str
     version: str
     wifi: Optional[Wifi]
+    user_mods: Optional[dict]
 
     @staticmethod
     def from_dict(data: Dict[str, Any]) -> Info:
@@ -227,6 +228,7 @@ class Info:
             version_id=data.get("vid", "Unknown"),
             version=data.get("ver", "Unknown"),
             wifi=Wifi.from_dict(data),
+            user_mods=data.get("u", None),
         )
 
 


### PR DESCRIPTION
Pretty simple: This adds the "u" property, which represents JSON values usermods can set. See these two usermods as an example:
* https://github.com/Aircoookie/WLED/blob/master/usermods/EXAMPLE_v2/usermod_v2_example.h
* https://github.com/Aircoookie/WLED/tree/master/usermods/Temperature

An example JSON looks like this:
```
{
	"info": {
		"u": {
			"Temperature": [22, "°C"]
		}
	}
}
```