### PR TITLE
Allow manual dispatching label workflow

### DIFF
--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -3,6 +3,7 @@ name: Sync labels
 
 # yamllint disable-line rule:truthy
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
# Proposed Changes

The labeling workflow didn't trigger due to the way I deployed the refactor of this package. This PR adds in the possibility to manually trigger the sync of labels.
