### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ development.
 
 You need at least:
 
-- Python 3.7+
+- Python 3.8+
 - [Poetry][poetry-install]
 - NodeJS 12+ (including NPM)
 

--- a/mypi.ini
+++ b/mypi.ini
@@ -2,7 +2,7 @@
 # Specify the target platform details in config, so your developers are
 # free to run mypy on Windows, Linux, or macOS and get consistent
 # results.
-python_version=3.7
+python_version=3.8
 platform=linux
 
 # flake8-mypy expects the two following for sensible formatting


### PR DESCRIPTION
# Proposed Changes

Support for Python 3.7 has been dropped.
This PR removed the last references.
