### PR TITLE
Remove deprecated pin info

### DIFF
--- a/src/wled/models.py
+++ b/src/wled/models.py
@@ -181,7 +181,6 @@ class Leds:
     fps: int | None
     max_power: int
     max_segments: int
-    pin: int
     power: int
     rgbw: bool
     wv: bool
@@ -202,7 +201,6 @@ class Leds:
             fps=leds.get("fps", None),
             max_power=leds.get("maxpwr", 0),
             max_segments=leds.get("maxseg", 0),
-            pin=leds.get("pin", 0),
             power=leds.get("pwr", 0),
             rgbw=leds.get("rgbw", False),
             wv=leds.get("wv", True),


### PR DESCRIPTION
# Proposed Changes

Removes WLED pin info, it is deprecated and will be removed from the API in WLED 0.13.0.
WLED now supports multiple PINs, so this info is kinda useless now.
