### PR TITLE
Fix support for older WLED presets

### DIFF
--- a/src/wled/models.py
+++ b/src/wled/models.py
@@ -435,6 +435,12 @@ class Preset:
         Returns:
             A Preset object.
         """
+        segment_data = data.get("seg", [])
+        if not isinstance(segment_data, list):
+            # Some older versions of WLED have an single segment
+            # instead of a list.
+            segment_data = [segment_data]
+
         segments = [
             Segment.from_dict(
                 segment_id=segment_id,
@@ -444,7 +450,7 @@ class Preset:
                 state_on=False,
                 state_brightness=0,
             )
-            for segment_id, segment in enumerate(data.get("seg", []))
+            for segment_id, segment in enumerate(segment_data)
         ]
 
         main_segment = next(


### PR DESCRIPTION
# Proposed Changes

If a WLED preset was created on an older version of WLED but carries along with the upgrades, it would end up having an older format.

In that case, the package would crash. This PR fixes that, by making a small adjustment to the format to support both the old and new styles.