### PR TITLE
Gracefully handle missing preset name

### DIFF
--- a/src/wled/models.py
+++ b/src/wled/models.py
@@ -460,7 +460,7 @@ class Preset:
 
         return Preset(
             main_segment=main_segment,
-            name=data["n"],
+            name=data.get("n", str(preset_id)),
             on=data.get("on", False),
             preset_id=preset_id,
             quick_label=data.get("ql"),


### PR DESCRIPTION
# Proposed Changes

Fixes a possible/reported case where preset has no name.

See: <https://github.com/home-assistant/core/issues/52762>