### PR TITLE
Use modern asyncio bootstrap in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ async def main():
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())
 ```
 
 ## Changelog & Releases

--- a/examples/control.py
+++ b/examples/control.py
@@ -23,5 +23,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/examples/upgrade.py
+++ b/examples/upgrade.py
@@ -16,5 +16,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/examples/websocket.py
+++ b/examples/websocket.py
@@ -27,5 +27,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())


### PR DESCRIPTION
# Proposed Changes

This library already requires Python 3.8, so no reason to keep the old bootstrap around (that spawns a deprecation warning in Python 3.10 anyways).
