### PR TITLE
WLED Upgrade improvements

### DIFF
--- a/examples/upgrade.py
+++ b/examples/upgrade.py
@@ -17,7 +17,10 @@ async def main():
         print("Upgrading WLED....")
         await led.upgrade(version="0.13.0-b4")
 
-        device = await led.update()
+        print("Waiting for WLED to come back....")
+        await asyncio.sleep(5)
+
+        device = await led.update(full_update=True)
         print(f"Current version: {device.info.version}")
 
 

--- a/examples/upgrade.py
+++ b/examples/upgrade.py
@@ -10,9 +10,15 @@ async def main():
     """Show example on upgrade your WLED device."""
     async with WLED("10.10.11.54") as led:
         device = await led.update()
-        print(device.info)
+        print(f"Latest stable version: {device.info.version_latest_stable}")
+        print(f"Latest beta version: {device.info.version_latest_beta}")
+        print(f"Current version: {device.info.version}")
 
+        print("Upgrading WLED....")
         await led.upgrade(version="0.13.0-b4")
+
+        device = await led.update()
+        print(f"Current version: {device.info.version}")
 
 
 if __name__ == "__main__":

--- a/src/wled/__init__.py
+++ b/src/wled/__init__.py
@@ -21,6 +21,7 @@ from .wled import (
     WLEDConnectionError,
     WLEDConnectionTimeoutError,
     WLEDError,
+    WLEDUpgradeError,
 )
 
 __all__ = [
@@ -42,4 +43,5 @@ __all__ = [
     "WLEDConnectionError",
     "WLEDConnectionTimeoutError",
     "WLEDError",
+    "WLEDUpgradeError",
 ]

--- a/src/wled/exceptions.py
+++ b/src/wled/exceptions.py
@@ -19,3 +19,7 @@ class WLEDConnectionTimeoutError(WLEDConnectionError):
 
 class WLEDConnectionClosed(WLEDConnectionError):
     """WLED WebSocket connection has been closed."""
+
+
+class WLEDUpgradeError(WLEDError):
+    """WLED upgrade exception."""

--- a/src/wled/wled.py
+++ b/src/wled/wled.py
@@ -610,8 +610,21 @@ class WLED:
         if self._device.info.version == version:
             raise WLEDUpgradeError("Device already running the requested version")
 
+        # Determine if this is an Ethernet board
+        ethernet = ""
+        if (
+            self._device.info.architecture == "esp32"
+            and self._device.info.wifi is not None
+            and not self._device.info.wifi.bssid
+            and self._device.info.version
+            and self._device.info.version >= "0.10.0"
+        ):
+            ethernet = "_Ethernet"
+
         url = URL.build(scheme="http", host=self.host, port=80, path="/update")
-        update_file = f"WLED_{version}_{self._device.info.architecture.upper()}.bin"
+        update_file = (
+            f"WLED_{version}_{self._device.info.architecture.upper()}{ethernet}.bin"
+        )
         download_url = f"https://github.com/Aircoookie/WLED/releases/download/v{version}/{update_file}"
 
         try:

--- a/src/wled/wled.py
+++ b/src/wled/wled.py
@@ -22,6 +22,7 @@ from .exceptions import (
     WLEDConnectionTimeoutError,
     WLEDEmptyResponseError,
     WLEDError,
+    WLEDUpgradeError,
 )
 from .models import Device, Live, Playlist, Preset
 
@@ -590,7 +591,7 @@ class WLED:
             version: The version to upgrade to.
 
         Raises:
-            WLEDError: If the upgrade fails.
+            WLEDUpgradeError: If the upgrade has failed.
             WLEDConnectionTimeoutError: When a connection timeout occurs.
             WLEDConnectionError: When a connection error occurs.
         """
@@ -598,10 +599,10 @@ class WLED:
             await self.update()
 
         if self.session is None or self._device is None:
-            return
+            raise WLEDUpgradeError("Unexpected upgrade error; No session or device")
 
         if self._device.info.architecture not in {"esp8266", "esp32"}:
-            raise WLEDError("Upgrade is only supported on ESP8266 and ESP32")
+            raise WLEDUpgradeError("Upgrade is only supported on ESP8266 and ESP32")
 
         url = URL.build(scheme="http", host=self.host, port=80, path="/update")
         update_file = f"WLED_{version}_{self._device.info.architecture.upper()}.bin"
@@ -621,10 +622,10 @@ class WLED:
             ) from exception
         except aiohttp.ClientResponseError as exception:
             if exception.status == 404:
-                raise WLEDError(
+                raise WLEDUpgradeError(
                     f"Requested WLED version '{version}' does not exists"
                 ) from exception
-            raise WLEDError(
+            raise WLEDUpgradeError(
                 f"Could not download requested WLED version '{version}' from {download_url}"
             ) from exception
         except (aiohttp.ClientError, socket.gaierror) as exception:

--- a/src/wled/wled.py
+++ b/src/wled/wled.py
@@ -604,6 +604,12 @@ class WLED:
         if self._device.info.architecture not in {"esp8266", "esp32"}:
             raise WLEDUpgradeError("Upgrade is only supported on ESP8266 and ESP32")
 
+        if not self._device.info.version:
+            raise WLEDUpgradeError("Current version is unknown, cannot perform upgrade")
+
+        if self._device.info.version == version:
+            raise WLEDUpgradeError("Device already running the requested version")
+
         url = URL.build(scheme="http", host=self.host, port=80, path="/update")
         update_file = f"WLED_{version}_{self._device.info.architecture.upper()}.bin"
         download_url = f"https://github.com/Aircoookie/WLED/releases/download/v{version}/{update_file}"


### PR DESCRIPTION
# Proposed Changes

More enhancements to the WLED Upgrade methods.

- Extended `upgrade.py` example
- Introduced and used a `WLEDUpgradeError`
- Don't upgrade if the version matches the already installed version
- Don't upgrade if the existing version is unknown
- Add support for ESP32 based Ethernet boards (thanks Aircoookie for the hints on that one!)

