### PR TITLE
Prevent model issues when preset 0 doesn't exists

### DIFF
--- a/src/wled/models.py
+++ b/src/wled/models.py
@@ -660,7 +660,7 @@ class Device:
             # we split those out, so we can handle those correctly.
 
             # Nobody cares about 0.
-            _presets.pop("0")
+            _presets.pop("0", None)
 
             presets = [
                 Preset.from_dict(int(preset_id), preset, self.effects, self.palettes)


### PR DESCRIPTION
# Proposed Changes

Fixes:

```txt
2021-11-27 13:34:25 ERROR (MainThread) [aiohttp.server] Error handling request
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/aiohttp/web_protocol.py", line 422, in _handle_request
    resp = await self._request_handler(request)
  File "/usr/local/lib/python3.9/site-packages/aiohttp/web_app.py", line 499, in _handle
    resp = await handler(request)
  File "/usr/local/lib/python3.9/site-packages/aiohttp/web_middlewares.py", line 119, in impl
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/security_filter.py", line 60, in security_filter_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/forwarded.py", line 98, in forwarded_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/request_context.py", line 24, in request_context_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/ban.py", line 78, in ban_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/auth.py", line 138, in auth_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/view.py", line 135, in handle
    result = await result
  File "/usr/src/homeassistant/homeassistant/components/config/config_entries.py", line 157, in post
    return await super().post(request, flow_id)
  File "/usr/src/homeassistant/homeassistant/components/http/data_validator.py", line 62, in wrapper
    result = await method(view, request, *args, **kwargs)
  File "/usr/src/homeassistant/homeassistant/helpers/data_entry_flow.py", line 110, in post
    result = await self._flow_mgr.async_configure(flow_id, data)
  File "/usr/src/homeassistant/homeassistant/data_entry_flow.py", line 246, in async_configure
    result = await self._async_handle_step(flow, cur_step["step_id"], user_input)
  File "/usr/src/homeassistant/homeassistant/data_entry_flow.py", line 320, in _async_handle_step
    result: FlowResult = await getattr(flow, method)(user_input)
  File "/usr/src/homeassistant/homeassistant/components/wled/config_flow.py", line 39, in async_step_user
    return await self._handle_config_flow(user_input)
  File "/usr/src/homeassistant/homeassistant/components/wled/config_flow.py", line 91, in _handle_config_flow
    device = await wled.update()
  File "/usr/local/lib/python3.9/site-packages/backoff/_async.py", line 133, in retry
    ret = await target(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/wled/wled.py", line 243, in update
    self._device = Device(data)
  File "/usr/local/lib/python3.9/site-packages/wled/models.py", line 575, in __init__
    self.update_from_dict(data)
  File "/usr/local/lib/python3.9/site-packages/wled/models.py", line 608, in update_from_dict
    _presets.pop("0")
KeyError: '0'
```

As reported on the WLED Discord