### PR TITLE
Accept Awesome version object as version argument in upgrade

### DIFF
--- a/src/wled/wled.py
+++ b/src/wled/wled.py
@@ -584,7 +584,7 @@ class WLED:
 
         await self.request("/json/state", method="POST", data=state)
 
-    async def upgrade(self, *, version: str) -> None:
+    async def upgrade(self, *, version: str | AwesomeVersion) -> None:
         """Upgrades WLED device to the specified version.
 
         Args:


### PR DESCRIPTION
# Proposed Changes

Adjust typing, so we accept Awesome version objects when calling `upgrade()` with a specific version.
