### PR TITLE
Allow version checks to GitHub to fail

### DIFF
--- a/src/wled/wled.py
+++ b/src/wled/wled.py
@@ -287,8 +287,9 @@ class WLED:
                     " response on state update"
                 )
 
-            versions = await self.get_wled_versions_from_github()
-            info.update(versions)
+            with suppress(WLEDError):
+                versions = await self.get_wled_versions_from_github()
+                info.update(versions)
 
             self._device.update_from_dict({"info": info, "state": state})
             return self._device
@@ -299,8 +300,9 @@ class WLED:
                 " response on state & info update"
             )
 
-        versions = await self.get_wled_versions_from_github()
-        state_info["info"].update(versions)
+        with suppress(WLEDError):
+            versions = await self.get_wled_versions_from_github()
+            state_info["info"].update(versions)
 
         self._device.update_from_dict(state_info)
 


### PR DESCRIPTION
# Proposed Changes

This changes the behavior around checking for new versions of WLED; it allows for the version check to fail silently. WLED is focused around local control, not having internet access or GitHub having outages, should not affect the working of the WLED device.

The typing is already correct, so this shouldn't be a problem.
