### PR TITLE
Refactor invalid version handling

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -966,7 +966,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "5ce1f07097757f6bca38337f7b0f3f7fc1ebfd61c3f3e003186605106607c547"
+content-hash = "202fa8b7dced1831cb1601b978d85713b18a0bf2d4588ec2a1a0104c9622bec2"
 
 [metadata.files]
 aiohttp = [
@@ -1583,10 +1583,6 @@ requests = [
     {file = "ruamel.yaml-0.17.20.tar.gz", hash = "sha256:4b8a33c1efb2b443a93fcaafcfa4d2e445f8e8c29c528d9f5cdafb7cc9e4004c"},
 ]
 "ruamel.yaml.clib" = [
-    {file = "ruamel.yaml.clib-0.2.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:6e7be2c5bcb297f5b82fee9c665eb2eb7001d1050deaba8471842979293a80b0"},
-    {file = "ruamel.yaml.clib-0.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:221eca6f35076c6ae472a531afa1c223b9c29377e62936f61bc8e6e8bdc5f9e7"},
-    {file = "ruamel.yaml.clib-0.2.6-cp310-cp310-win32.whl", hash = "sha256:1070ba9dd7f9370d0513d649420c3b362ac2d687fe78c6e888f5b12bf8bc7bee"},
-    {file = "ruamel.yaml.clib-0.2.6-cp310-cp310-win_amd64.whl", hash = "sha256:77df077d32921ad46f34816a9a16e6356d8100374579bc35e15bab5d4e9377de"},
     {file = "ruamel.yaml.clib-0.2.6-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:cfdb9389d888c5b74af297e51ce357b800dd844898af9d4a547ffc143fa56751"},
     {file = "ruamel.yaml.clib-0.2.6-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:7b2927e92feb51d830f531de4ccb11b320255ee95e791022555971c466af4527"},
     {file = "ruamel.yaml.clib-0.2.6-cp35-cp35m-win32.whl", hash = "sha256:ada3f400d9923a190ea8b59c8f60680c4ef8a4b0dfae134d2f2ff68429adfab5"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ python = "^3.8"
 aiohttp = ">=3.0.0"
 yarl = ">=1.6.0"
 backoff = ">=1.9.0"
-awesomeversion = ">=21.10.1"
+awesomeversion = ">=22.1.0"
 cachetools = ">=4.0.0"
 
 [tool.poetry.dev-dependencies]

--- a/src/wled/models.py
+++ b/src/wled/models.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from enum import IntEnum
 from typing import Any
 
-from awesomeversion import AwesomeVersion, AwesomeVersionStrategy
+from awesomeversion import AwesomeVersion
 
 from .exceptions import WLEDError
 
@@ -339,8 +339,7 @@ class Info:  # pylint: disable=too-many-instance-attributes
 
         if version := data.get("ver"):
             version = AwesomeVersion(version)
-            # If version straight is unknown, ditch it.
-            if version.strategy == AwesomeVersionStrategy.UNKNOWN:
+            if not version.valid:
                 version = None
 
         if version_latest_stable := data.get("version_latest_stable"):


### PR DESCRIPTION
# Proposed Changes

Awesome version `>=22.1.0` now supports `version.valid` 🎉 

Just slightly cleaner 🧹 
