### PR TITLE
Fix nightlight mode for sunrise

### DIFF
--- a/src/wled/wled.py
+++ b/src/wled/wled.py
@@ -584,12 +584,7 @@ class WLED:
 
         # Filter out not set values
         nightlight = {k: v for k, v in nightlight.items() if v is not None}
-
-        state: dict[str, Any] = {"nl": nightlight}
-        if on:
-            state["on"] = True
-
-        await self.request("/json/state", method="POST", data=state)
+        await self.request("/json/state", method="POST", data={"nl": nightlight})
 
     async def upgrade(self, *, version: str | AwesomeVersion) -> None:
         """Upgrades WLED device to the specified version.


### PR DESCRIPTION
# Proposed Changes

The nightlight mode can be used for sunrise simulation as well (turning the light on).
This PR addresses an issue that made it impossible to use it for that case, as it would always turn the light on.

## Related Issues

Ref: https://github.com/home-assistant/core/issues/65307
