### PR TITLE
Fix offline operation

### DIFF
--- a/src/wled/wled.py
+++ b/src/wled/wled.py
@@ -249,8 +249,9 @@ class WLED:
             except WLEDError:
                 self._supports_presets = False
 
-            versions = await self.get_wled_versions_from_github()
-            data["info"].update(versions)
+            with suppress(WLEDError):
+                versions = await self.get_wled_versions_from_github()
+                data["info"].update(versions)
 
             self._device = Device(data)
 

--- a/tests/test_wled.py
+++ b/tests/test_wled.py
@@ -17,7 +17,7 @@ def mock_get_version_from_github() -> Generator[None, None, None]:
     with patch(
         "wled.WLED.get_wled_versions_from_github",
         return_value={"version_latest_stable": None, "version_latest_beta": None},
-        side_effect=WLEDConnectionError
+        side_effect=WLEDConnectionError,
     ):
         yield
 

--- a/tests/test_wled.py
+++ b/tests/test_wled.py
@@ -17,6 +17,7 @@ def mock_get_version_from_github() -> Generator[None, None, None]:
     with patch(
         "wled.WLED.get_wled_versions_from_github",
         return_value={"version_latest_stable": None, "version_latest_beta": None},
+        side_effect=WLEDConnectionError
     ):
         yield
 


### PR DESCRIPTION
# Proposed Changes
As discussed in [ Issue #584  ](https://github.com/frenck/python-wled/issues/584), suppressing errors raised by ```get_wled_versions_from_github()``` fixes offline operation for the library as well as the WLED integration for Home Assistant.

I tested this using the filter function of my router, when blocking github.com, I got this trace:

```
(wled-k_bysTn7-py3.9) simon@obelix:/mnt/c/repositories/stuff/python-wled$ python examples/control.py
Traceback (most recent call last):
  File "/home/simon/.cache/pypoetry/virtualenvs/wled-k_bysTn7-py3.9/lib/python3.9/site-packages/aiohttp/connector.py", line 986, in _wrap_create_connection
    return await self._loop.create_connection(*args, **kwargs)  # type: ignore[return-value]  # noqa
  File "/usr/lib/python3.9/asyncio/base_events.py", line 1081, in create_connection
    transport, protocol = await self._create_connection_transport(
  File "/usr/lib/python3.9/asyncio/base_events.py", line 1111, in _create_connection_transport
    await waiter
  File "/usr/lib/python3.9/asyncio/sslproto.py", line 528, in data_received
    ssldata, appdata = self._sslpipe.feed_ssldata(data)
  File "/usr/lib/python3.9/asyncio/sslproto.py", line 188, in feed_ssldata
    self._sslobj.do_handshake()
  File "/usr/lib/python3.9/ssl.py", line 944, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLError: [SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:1129)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/mnt/c/repositories/stuff/python-wled/src/wled/wled.py", line 683, in get_wled_versions_from_github
    response = await self.session.get(
  File "/home/simon/.cache/pypoetry/virtualenvs/wled-k_bysTn7-py3.9/lib/python3.9/site-packages/aiohttp/client.py", line 535, in _request
    conn = await self._connector.connect(
  File "/home/simon/.cache/pypoetry/virtualenvs/wled-k_bysTn7-py3.9/lib/python3.9/site-packages/aiohttp/connector.py", line 542, in connect
    proto = await self._create_connection(req, traces, timeout)
  File "/home/simon/.cache/pypoetry/virtualenvs/wled-k_bysTn7-py3.9/lib/python3.9/site-packages/aiohttp/connector.py", line 907, in _create_connection
    _, proto = await self._create_direct_connection(req, traces, timeout)
  File "/home/simon/.cache/pypoetry/virtualenvs/wled-k_bysTn7-py3.9/lib/python3.9/site-packages/aiohttp/connector.py", line 1206, in _create_direct_connection
    raise last_exc
  File "/home/simon/.cache/pypoetry/virtualenvs/wled-k_bysTn7-py3.9/lib/python3.9/site-packages/aiohttp/connector.py", line 1175, in _create_direct_connection
    transp, proto = await self._wrap_create_connection(
  File "/home/simon/.cache/pypoetry/virtualenvs/wled-k_bysTn7-py3.9/lib/python3.9/site-packages/aiohttp/connector.py", line 990, in _wrap_create_connection
    raise ClientConnectorSSLError(req.connection_key, exc) from exc
aiohttp.client_exceptions.ClientConnectorSSLError: Cannot connect to host api.github.com:443 ssl:default [[SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:1129)]

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/mnt/c/repositories/stuff/python-wled/examples/control.py", line 26, in <module>
    asyncio.run(main())
  File "/usr/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/mnt/c/repositories/stuff/python-wled/examples/control.py", line 12, in main
    device = await led.update()
  File "/home/simon/.cache/pypoetry/virtualenvs/wled-k_bysTn7-py3.9/lib/python3.9/site-packages/backoff/_async.py", line 133, in retry
    ret = await target(*args, **kwargs)
  File "/mnt/c/repositories/stuff/python-wled/src/wled/wled.py", line 252, in update
    versions = await self.get_wled_versions_from_github()
  File "/home/simon/.cache/pypoetry/virtualenvs/wled-k_bysTn7-py3.9/lib/python3.9/site-packages/backoff/_async.py", line 133, in retry
    ret = await target(*args, **kwargs)
  File "/mnt/c/repositories/stuff/python-wled/src/wled/wled.py", line 692, in get_wled_versions_from_github
    raise WLEDConnectionError(
wled.exceptions.WLEDConnectionError: Timeout occurred while communicating with GitHub for WLED version
```

After the change I was able to run the example script `example/control.py' without issues, even if github.com is not reachable/blocked.

Furthermore, I raised a `WLEDConnectionError` in the test suite. Although all tests pass, I'm not 100% sure, this is what we want.

## Related Issues
* https://github.com/frenck/python-wled/issues/584
* https://github.com/home-assistant/core/issues/67547