### PR TITLE
Add (undocumented) manual white light capability

### DIFF
--- a/src/wled/models.py
+++ b/src/wled/models.py
@@ -727,11 +727,11 @@ class LightCapability(IntFlag):
     RGB_COLOR = 1
     WHITE_CHANNEL = 2
     COLOR_TEMPERATURE = 4
+    MANUAL_WHITE = 8
 
     # These are not used, but are reserved for future use.
     # WLED specifications documents we should expect them,
     # therefore, we include them here.
-    RESERVED_1 = 8
     RESERVED_2 = 16
     RESERVED_3 = 32
     RESERVED_4 = 64


### PR DESCRIPTION
# Proposed Changes

Add support for the manual white light capability (which is unfortunately undocumented).

Ref:
- https://github.com/Aircoookie/WLED/blob/6d1ff7c3f367ba5932fb4e118899a9afb5e0849a/wled00/FX_fcn.cpp#L693
- https://github.com/Aircoookie/WLED/blob/6d1ff7c3f367ba5932fb4e118899a9afb5e0849a/wled00/data/index.js#L1299 
