### PR TITLE
new-feature: Support for Segment Names

### DIFF
--- a/src/wled/models.py
+++ b/src/wled/models.py
@@ -120,6 +120,7 @@ class Segment:
     effect: Effect
     intensity: int
     length: int
+    name: str
     on: bool
     palette: Palette
     reverse: bool
@@ -130,7 +131,7 @@ class Segment:
     stop: int
 
     @staticmethod
-    def from_dict(
+    def from_dict(  # pylint: disable=R0914
         segment_id: int,
         data: dict[str, Any],
         *,
@@ -157,7 +158,7 @@ class Segment:
         start = data.get("start", 0)
         stop = data.get("stop", 0)
         length = data.get("len", (stop - start))
-
+        name = data.get("n", "")
         colors = data.get("col", [])
         primary_color, secondary_color, tertiary_color = (0, 0, 0)
         try:
@@ -185,6 +186,7 @@ class Segment:
             effect=effect,
             intensity=data.get("ix", 0),
             length=length,
+            name=name,
             on=data.get("on", state_on),
             palette=palette,
             reverse=data.get("rev", False),


### PR DESCRIPTION
# Proposed Changes

Adding `n` (Name) to segments. Ultimately I'd like home assistant to create lights based on segment names using the WLED integration so I think this change is needed.

The 'n' field exists in the webscoket message - so should hopefully be pretty simple...


![image](https://user-images.githubusercontent.com/6491743/228315099-3d0a2232-46b9-4fc5-9c63-3ae4e5d6a4ba.png)


## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
