### PR TITLE
Added CCT support

### DIFF
--- a/src/wled/models.py
+++ b/src/wled/models.py
@@ -117,6 +117,7 @@ class Segment:
     color_primary: tuple[int, int, int, int] | tuple[int, int, int]
     color_secondary: tuple[int, int, int, int] | tuple[int, int, int]
     color_tertiary: tuple[int, int, int, int] | tuple[int, int, int]
+    cct: int
     effect: Effect
     intensity: int
     length: int
@@ -183,6 +184,7 @@ class Segment:
             color_primary=primary_color,  # type: ignore[arg-type]
             color_secondary=secondary_color,  # type: ignore[arg-type]
             color_tertiary=tertiary_color,  # type: ignore[arg-type]
+            cct=data.get("cct", 0),
             effect=effect,
             intensity=data.get("ix", 0),
             length=length,

--- a/src/wled/wled.py
+++ b/src/wled/wled.py
@@ -343,6 +343,7 @@ class WLED:
         brightness: int | None = None,
         on: bool | None = None,
         transition: int | None = None,
+        cct: int | None = None
     ) -> None:
         """Change master state of a WLED Light device.
 
@@ -353,6 +354,7 @@ class WLED:
             transition: Duration of the crossfade between different
                 colors/brightness levels. One unit is 100ms, so a value of 4
                 results in a transition of 400ms.
+            cct:
         """
         state: dict[str, bool | int] = {}
 
@@ -364,6 +366,9 @@ class WLED:
 
         if transition is not None:
             state["tt"] = transition
+
+        if cct is not None:
+            state["cct"] = cct
 
         await self.request("/json/state", method="POST", data=state)
 
@@ -392,6 +397,7 @@ class WLED:
         start: int | None = None,
         stop: int | None = None,
         transition: int | None = None,
+        cct: int | None = None
     ) -> None:
         """Change state of a WLED Light segment.
 
@@ -420,6 +426,7 @@ class WLED:
             transition:  Duration of the crossfade between different
                 colors/brightness levels. One unit is 100ms, so a value of 4
                 results in a transition of 400ms.
+            cct: The white spectrum color temperature.
 
         Raises:
         ------
@@ -447,6 +454,7 @@ class WLED:
             "start": start,
             "stop": stop,
             "sx": speed,
+            "cct": cct
         }
 
         # > WLED 0.10.0, does not support segment control on/bri.


### PR DESCRIPTION
# Proposed Changes

- Introduced support for CCT (Correlated Color Temperature) in the WLED module.
  - Added `cct` parameter in the `master` and `segment` methods of the `wled.py` to change the state of a WLED Light device and WLED Light segment respectively.

## Related Issues

- [#977] Support for CCT