### PR TITLE
Fix firmware upgrade for 2M ESP8266 boards

### DIFF
--- a/src/wled/wled.py
+++ b/src/wled/wled.py
@@ -700,9 +700,8 @@ class WLED:
             gzip = ".gz"
 
         url = URL.build(scheme="http", host=self.host, port=80, path="/update")
-        update_file = (
-            f"WLED_{version}_{self._device.info.architecture.upper()}{ethernet}.bin{gzip}"
-        )
+        architecture = self._device.info.architecture.upper()
+        update_file = f"WLED_{version}_{architecture}{ethernet}.bin{gzip}"
         download_url = (
             "https://github.com/Aircoookie/WLED/releases/download"
             f"/v{version}/{update_file}"

--- a/src/wled/wled.py
+++ b/src/wled/wled.py
@@ -693,9 +693,15 @@ class WLED:
         ):
             ethernet = "_Ethernet"
 
+        # Determine if this is a 2M ESP8266 board.
+        # See issue `https://github.com/Aircoookie/WLED/issues/3257`
+        gzip = ""
+        if self._device.info.architecture == "esp02":
+            gzip = ".gz"
+
         url = URL.build(scheme="http", host=self.host, port=80, path="/update")
         update_file = (
-            f"WLED_{version}_{self._device.info.architecture.upper()}{ethernet}.bin"
+            f"WLED_{version}_{self._device.info.architecture.upper()}{ethernet}.bin{gzip}"
         )
         download_url = (
             "https://github.com/Aircoookie/WLED/releases/download"


### PR DESCRIPTION
# Proposed Changes
Fix firmware upgrade for 2M ESP8266 boards.
Due to space constraints, only gzip-compressed binaries should be used for upgrade ESP8266 devices with 2M memory. 

## Related Issues
A more detailed explanations can be found at [issue on WLED project page](https://github.com/Aircoookie/WLED/issues/3257)
