### PR TITLE
Fixed KeyError in Device on incomplete dict

### DIFF
--- a/src/wled/models.py
+++ b/src/wled/models.py
@@ -710,7 +710,7 @@ class Device:
 
         # Check if all elements are in the passed dict, else raise an Error
         if any(
-            k not in data and data[k] is not None
+            k not in data or data[k] is None
             for k in ("effects", "palettes", "info", "state")
         ):
             msg = "WLED data is incomplete, cannot construct device object"

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,38 @@
+"""Tests for `wled.Device`."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from wled import Device
+from wled.exceptions import WLEDError
+
+
+def test_init_valid_empty_dict() -> None:
+    """Test device can be created from basic json."""
+    testdata: dict[str, Any] = {"effects": [], "palettes": [], "info": {}, "state": {}}
+    device = Device(testdata)
+    assert device is not None
+    assert isinstance(device, Device)
+
+
+@pytest.mark.parametrize(
+    "test_dict",
+    [
+        {},
+        {"effects": None, "palettes": [], "info": {}, "state": {}},
+        {"effects": [], "palettes": None, "info": {}, "state": {}},
+        {"effects": [], "palettes": [], "info": None, "state": {}},
+        {"effects": [], "palettes": [], "info": {}, "state": None},
+        {"palettes": [], "info": {}, "state": {}},
+        {"effects": [], "info": {}, "state": {}},
+        {"effects": [], "palettes": [], "state": {}},
+        {"effects": [], "palettes": [], "info": {}},
+    ],
+)
+def test_init_faulty_dict(test_dict: dict[str, Any]) -> None:
+    """Test construction properly errors out on missing or empty keys."""
+    with pytest.raises(WLEDError, match=r"WLED data is incomplete.*"):
+        Device(test_dict)


### PR DESCRIPTION
# Proposed Changes

> The checks for presence of the sections "info", "effects", "palettes" and "state" had a bug, leading to a KeyError if sections were missing. Instead a proper WLEDError should be thrown.

## Related Issues

> This kind of relates to some issues with WLED 0.14 and segmented strips, but won't fix these issues.