### PR TITLE
Add support for ESP32-C3, ESP32-S2, and ESP32-S3 board types

### DIFF
--- a/src/wled/wled.py
+++ b/src/wled/wled.py
@@ -670,8 +670,11 @@ class WLED:
             "esp02",
             "esp32",
             "esp8266",
+            "esp32-c3",
+            "esp32-s2",
+            "esp32-s3",
         }:
-            msg = "Upgrade is only supported on ESP01, ESP02, ESP32 and ESP8266 devices"
+            msg = "Upgrade is only supported on ESP01, ESP02, ESP32, ESP8266, ESP32-C3, ESP32-S2, and ESP32-S3 devices"
             raise WLEDUpgradeError(msg)
 
         if not self._device.info.version:


### PR DESCRIPTION
Related to #1140

Adds support for upgrading ESP32-C3, ESP32-S2, and ESP32-S3 board types in the WLED project.

- Updates the `upgrade` method in `src/wled/wled.py` to include ESP32-C3, ESP32-S2, and ESP32-S3 alongside the previously supported ESP01, ESP02, ESP32, and ESP8266 devices.
- Modifies the architecture check within the `upgrade` method to recognize and allow upgrades for the new board types.
- Adjusts the error message in the `WLEDUpgradeError` exception to reflect the inclusion of the new supported board types.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/frenck/python-wled/issues/1140?shareId=e9279629-5739-497c-8e2a-e21e91c90349).