### PR TITLE
Case-insensitive comparison of architecture values

### DIFF
--- a/src/wled/models.py
+++ b/src/wled/models.py
@@ -488,6 +488,9 @@ class Info(BaseModel):  # pylint: disable=too-many-instance-attributes
         if obj.websocket == -1:
             obj.websocket = None
 
+        # We want the architecture in lower case
+        obj.architecture = obj.architecture.lower()
+
         # We can tweak the architecture name based on the filesystem size.
         if obj.filesystem is not None and obj.architecture == "esp8266":
             if obj.filesystem.total <= 256:
@@ -807,8 +810,6 @@ class Device(BaseModel):
             self.playlists.pop(0, None)
 
         if _info := data.get("info"):
-            if "architecture" in _info:
-                _info["architecture"] = _info["architecture"].lower()
             self.info = Info.from_dict(_info)
 
         if _state := data.get("state"):

--- a/src/wled/models.py
+++ b/src/wled/models.py
@@ -489,7 +489,7 @@ class Info(BaseModel):  # pylint: disable=too-many-instance-attributes
             obj.websocket = None
 
         # We can tweak the architecture name based on the filesystem size.
-        if obj.filesystem is not None and obj.architecture == "esp8266":
+        if obj.filesystem is not None and obj.architecture.lower() == "esp8266":
             if obj.filesystem.total <= 256:
                 obj.architecture = "esp01"
             elif obj.filesystem.total <= 512:

--- a/src/wled/models.py
+++ b/src/wled/models.py
@@ -489,7 +489,7 @@ class Info(BaseModel):  # pylint: disable=too-many-instance-attributes
             obj.websocket = None
 
         # We can tweak the architecture name based on the filesystem size.
-        if obj.filesystem is not None and obj.architecture.lower() == "esp8266":
+        if obj.filesystem is not None and obj.architecture == "esp8266":
             if obj.filesystem.total <= 256:
                 obj.architecture = "esp01"
             elif obj.filesystem.total <= 512:
@@ -807,6 +807,8 @@ class Device(BaseModel):
             self.playlists.pop(0, None)
 
         if _info := data.get("info"):
+            if "architecture" in _info:
+                _info["architecture"] = _info["architecture"].lower()
             self.info = Info.from_dict(_info)
 
         if _state := data.get("state"):

--- a/src/wled/models.py
+++ b/src/wled/models.py
@@ -407,7 +407,7 @@ class Filesystem(BaseModel):
 class Info(BaseModel):  # pylint: disable=too-many-instance-attributes
     """Object holding information from WLED."""
 
-    architecture: str = field(default="Unknown", metadata=field_options(alias="arch"))
+    architecture: str = field(default="unknown", metadata=field_options(alias="arch"))
     """Name of the platform."""
 
     arduino_core_version: str = field(

--- a/src/wled/wled.py
+++ b/src/wled/wled.py
@@ -590,7 +590,7 @@ class WLED:
             msg = "Unexpected upgrade error; No session or device"
             raise WLEDUpgradeError(msg)
 
-        if self._device.info.architecture.lower() not in {
+        if self._device.info.architecture not in {
             "esp01",
             "esp02",
             "esp32",
@@ -616,7 +616,7 @@ class WLED:
         # Determine if this is an Ethernet board
         ethernet = ""
         if (
-            self._device.info.architecture.lower() == "esp32"
+            self._device.info.architecture == "esp32"
             and self._device.info.wifi is not None
             and not self._device.info.wifi.bssid
             and self._device.info.version
@@ -627,7 +627,7 @@ class WLED:
         # Determine if this is a 2M ESP8266 board.
         # See issue `https://github.com/Aircoookie/WLED/issues/3257`
         gzip = ""
-        if self._device.info.architecture.lower() == "esp02":
+        if self._device.info.architecture == "esp02":
             gzip = ".gz"
 
         url = URL.build(scheme="http", host=self.host, port=80, path="/update")

--- a/src/wled/wled.py
+++ b/src/wled/wled.py
@@ -590,7 +590,7 @@ class WLED:
             msg = "Unexpected upgrade error; No session or device"
             raise WLEDUpgradeError(msg)
 
-        if self._device.info.architecture not in {
+        if self._device.info.architecture.lower() not in {
             "esp01",
             "esp02",
             "esp32",
@@ -616,7 +616,7 @@ class WLED:
         # Determine if this is an Ethernet board
         ethernet = ""
         if (
-            self._device.info.architecture == "esp32"
+            self._device.info.architecture.lower() == "esp32"
             and self._device.info.wifi is not None
             and not self._device.info.wifi.bssid
             and self._device.info.version
@@ -627,7 +627,7 @@ class WLED:
         # Determine if this is a 2M ESP8266 board.
         # See issue `https://github.com/Aircoookie/WLED/issues/3257`
         gzip = ""
-        if self._device.info.architecture == "esp02":
+        if self._device.info.architecture.lower() == "esp02":
             gzip = ".gz"
 
         url = URL.build(scheme="http", host=self.host, port=80, path="/update")


### PR DESCRIPTION
# Proposed Changes

Architecture values from WLED don't appear to have consistent case. So better to do case-insensitive comparisons.

![image](https://github.com/frenck/python-wled/assets/1047337/34067dd2-b8f2-49aa-affd-526d89bf4bcd)

![image](https://github.com/frenck/python-wled/assets/1047337/50b8cabb-c914-4f01-97e6-835c7e2a07de)

Causes incorrect errors when updating WLED firmware on ESP32-C3 via HomeAssistant.

## Related Issues

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Ensured case-insensitive handling of the architecture field across various methods for better consistency and reliability.
- **Bug Fixes**
  - Fixed issues related to architecture comparison by converting architecture names to lowercase before comparison.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->