### PR TITLE
Fix link to contribution guidelines in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This is an active open-source project. We are always open to people who want to
 use the code or contribute to it.
 
 We've set up a separate document for our
-[contribution guidelines](CONTRIBUTING.md).
+[contribution guidelines](.github/CONTRIBUTING.md).
 
 Thank you for being involved! :heart_eyes:
 


### PR DESCRIPTION
The file was moved a while ago into the `.github` folder.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected links to the contribution guidelines to point to their updated location in the repository’s community area.
  * Improves navigation for contributors and reduces confusion from outdated references.
  * Enhances onboarding clarity and keeps documentation consistent with the current project structure.
  * No changes to features, behavior, interfaces, or error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->