### PR TITLE
Listen for preset changes

### DIFF
--- a/src/wled/wled.py
+++ b/src/wled/wled.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import socket
+import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Self
 
@@ -31,6 +32,14 @@ if TYPE_CHECKING:
 
 
 @dataclass
+class _PresetsVersion:
+    """Tracks preset modification state to avoid unnecessary fetches."""
+
+    modified_timestamp: int
+    boot_time: int
+
+
+@dataclass
 class WLED:
     """Main class for handling connections with WLED."""
 
@@ -41,6 +50,7 @@ class WLED:
     _client: aiohttp.ClientWebSocketResponse | None = None
     _close_session: bool = False
     _device: Device | None = None
+    _presets_version: _PresetsVersion | None = None
 
     @property
     def connected(self) -> bool:
@@ -119,7 +129,19 @@ class WLED:
 
             if message.type == aiohttp.WSMsgType.TEXT:
                 message_data = message.json()
+
+                changed, new_version = self._check_presets_changed(message_data)
+                if changed:
+                    if not (presets := await self.request("/presets.json")):
+                        msg = (
+                            f"WLED device at {self.host} returned an empty API"
+                            " response on presets update",
+                        )
+                        raise WLEDEmptyResponseError(msg)
+                    message_data["presets"] = presets
+
                 device = self._device.update_from_dict(data=message_data)
+                self._presets_version = new_version
                 callback(device)
 
             if message.type in (
@@ -256,19 +278,22 @@ class WLED:
             )
             raise WLEDEmptyResponseError(msg)
 
-        if not (presets := await self.request("/presets.json")):
-            msg = (
-                f"WLED device at {self.host} returned an empty API"
-                " response on presets update",
-            )
-            raise WLEDEmptyResponseError(msg)
-        data["presets"] = presets
+        changed, new_version = self._check_presets_changed(data)
+        if changed:
+            if not (presets := await self.request("/presets.json")):
+                msg = (
+                    f"WLED device at {self.host} returned an empty API"
+                    " response on presets update",
+                )
+                raise WLEDEmptyResponseError(msg)
+            data["presets"] = presets
 
         if not self._device:
             self._device = Device.from_dict(data)
         else:
             self._device.update_from_dict(data)
 
+        self._presets_version = new_version
         return self._device
 
     async def master(
@@ -713,6 +738,52 @@ class WLED:
 
         """
         await self.close()
+
+    def _check_presets_changed(
+        self, data: dict[str, Any]
+    ) -> tuple[bool, _PresetsVersion | None]:
+        """Check if presets have changed since the last check.
+
+        Compares the preset modification timestamp (pmt) and approximate
+        boot time to detect changes. Boot time tracking is needed because
+        pmt is stored in volatile memory and resets to 0 on device restart.
+
+        Returns
+        -------
+            A tuple of (changed, new_version). If the version cannot be
+            determined from the data, returns (True, None) to trigger a
+            safe refetch.
+
+        """
+        if not isinstance(data, dict) or "info" not in data:
+            # No info in message (e.g. state-only WebSocket update),
+            # presets can't have changed.
+            return (False, self._presets_version)
+
+        info = data["info"]
+        if (
+            not (uptime := info.get("uptime"))
+            or not (fs := info.get("fs"))
+            or not (pmt := fs.get("pmt"))
+        ):
+            return (True, None)
+
+        try:
+            new_version = _PresetsVersion(
+                modified_timestamp=int(pmt),
+                boot_time=int(time.time()) - int(uptime),
+            )
+        except (ValueError, TypeError):
+            return (True, None)
+
+        if self._presets_version is None:
+            return (True, new_version)
+
+        changed = (
+            self._presets_version.modified_timestamp != new_version.modified_timestamp
+            or abs(self._presets_version.boot_time - new_version.boot_time) > 2
+        )
+        return (changed, new_version)
 
 
 @dataclass

--- a/tests/test_wled.py
+++ b/tests/test_wled.py
@@ -231,6 +231,166 @@ async def test_update_empty_presets_response() -> None:
                 await wled.update()
 
 
+async def test_update_skips_presets_when_unchanged() -> None:
+    """Test update() skips fetching presets.json when presets haven't changed."""
+    wled_data = load_fixture_json("wled")
+
+    with aioresponses() as mocked:
+        # First update: fetches both /json and /presets.json
+        mocked.get(
+            "http://example.com/json",
+            status=200,
+            body=json.dumps(wled_data),
+            content_type="application/json",
+        )
+        mocked.get(
+            "http://example.com/presets.json",
+            status=200,
+            body=json.dumps(load_fixture_json("presets")),
+            content_type="application/json",
+        )
+        # Second update: same pmt and uptime, only /json fetched
+        mocked.get(
+            "http://example.com/json",
+            status=200,
+            body=json.dumps(wled_data),
+            content_type="application/json",
+        )
+        # Third update: pmt changed, fetches /presets.json again
+        changed_data = json.loads(json.dumps(wled_data))
+        changed_data["info"]["fs"]["pmt"] = 9999999999.0
+        mocked.get(
+            "http://example.com/json",
+            status=200,
+            body=json.dumps(changed_data),
+            content_type="application/json",
+        )
+        mocked.get(
+            "http://example.com/presets.json",
+            status=200,
+            body=json.dumps({"0": {}, "1": {"n": "Updated Preset"}}),
+            content_type="application/json",
+        )
+
+        async with aiohttp.ClientSession() as session:
+            wled = WLED("example.com", session=session)
+
+            # First call: presets fetched
+            device = await wled.update()
+            assert device.presets[1].name == "My Preset"
+
+            # Second call: presets unchanged, not refetched
+            device = await wled.update()
+            assert device.presets[1].name == "My Preset"
+
+            # Third call: pmt changed, presets refetched
+            device = await wled.update()
+            assert device.presets[1].name == "Updated Preset"
+
+
+async def test_update_refetches_presets_when_info_incomplete() -> None:
+    """Test update() refetches presets when pmt is zero/missing."""
+    wled_data = load_fixture_json("wled")
+    # Set pmt to 0 so version can't be determined
+    wled_data["info"]["fs"]["pmt"] = 0
+
+    with aioresponses() as mocked:
+        mocked.get(
+            "http://example.com/json",
+            status=200,
+            body=json.dumps(wled_data),
+            content_type="application/json",
+        )
+        mocked.get(
+            "http://example.com/presets.json",
+            status=200,
+            body=json.dumps(load_fixture_json("presets")),
+            content_type="application/json",
+        )
+        # Second call: still no fs, presets refetched again
+        mocked.get(
+            "http://example.com/json",
+            status=200,
+            body=json.dumps(wled_data),
+            content_type="application/json",
+        )
+        mocked.get(
+            "http://example.com/presets.json",
+            status=200,
+            body=json.dumps(load_fixture_json("presets")),
+            content_type="application/json",
+        )
+
+        async with aiohttp.ClientSession() as session:
+            wled = WLED("example.com", session=session)
+            await wled.update()
+            # Without fs/pmt, every update refetches presets
+            await wled.update()
+
+
+async def test_listen_preset_change_via_websocket() -> None:
+    """Test listen() detects preset changes and refetches presets.json."""
+    wled_data = load_fixture_json("wled")
+
+    wled = WLED("example.com")
+    mock_client = MagicMock()
+    mock_client.closed = False
+    wled._client = mock_client  # pylint: disable=protected-access
+    wled._device = Device.from_dict(full_device_data())  # pylint: disable=protected-access
+
+    # WS message with full info (includes fs.pmt) triggers preset check
+    text_msg = MagicMock()
+    text_msg.type = aiohttp.WSMsgType.TEXT
+    text_msg.json.return_value = wled_data
+
+    close_msg = MagicMock()
+    close_msg.type = aiohttp.WSMsgType.CLOSE
+
+    mock_client.receive = AsyncMock(side_effect=[text_msg, close_msg])
+
+    with aioresponses() as mocked:
+        mocked.get(
+            "http://example.com/presets.json",
+            status=200,
+            body=json.dumps(load_fixture_json("presets")),
+            content_type="application/json",
+        )
+
+        callback = MagicMock()
+        with pytest.raises(WLEDConnectionClosedError):
+            await wled.listen(callback)
+
+        callback.assert_called_once()
+
+
+async def test_listen_preset_change_empty_response() -> None:
+    """Test listen() raises when preset refetch returns empty."""
+    wled_data = load_fixture_json("wled")
+
+    wled = WLED("example.com")
+    mock_client = MagicMock()
+    mock_client.closed = False
+    wled._client = mock_client  # pylint: disable=protected-access
+    wled._device = Device.from_dict(full_device_data())  # pylint: disable=protected-access
+
+    text_msg = MagicMock()
+    text_msg.type = aiohttp.WSMsgType.TEXT
+    text_msg.json.return_value = wled_data
+
+    mock_client.receive = AsyncMock(return_value=text_msg)
+
+    with aioresponses() as mocked:
+        mocked.get(
+            "http://example.com/presets.json",
+            status=200,
+            body="",
+            content_type="text/plain",
+        )
+
+        with pytest.raises(WLEDEmptyResponseError):
+            await wled.listen(MagicMock())
+
+
 # =========================================================================
 # Section 11: WLED client - master() method
 # =========================================================================


### PR DESCRIPTION
# Proposed Changes

This PR makes `listen()` detect changes to Presets. It also avoids fetching `presets.json` in `update()` when presets haven't changed.

Potential changes to presets are detected two ways: If WLED's announces a change in `pmt` aka presetsModifiedTime or if the WLED device is restarted. Restart detection is needed since presetsModifiedTime is only stored in the volatile memory.

Home Assistant uses `listen()` but also polls `update()` every 10 seconds. My understanding the polling is needed to update the Presets. The intent of this PR is to allow removing the polling in the future by making the `listen()` return all needed information, and immediately reduce the amount of polling to `presets.json`.

Polling `presets.json` is problematic as it causes visual glitching on WLED devices. On many ESP devices, fetching the file results in reads from the flash storage on the chip. For reasons beoynd my undestanding, this apparently breaks some interrupts on some firmware versions and led output gets corrupted. On better firmware, it only causes the led animations to stutter.

WLED community is very aware of the HASS polling behavior, and has attempted to work around it with some [caching tricks](https://github.com/wled/WLED/blob/0_15_x/wled00/file.cpp#L379-L383). These only reduce the issues and require special hardware (PSRAM) to be installed. Some users have switched to [MQTT based HASS integration](https://github.com/dmonty2/homeassistant_wled_mqtt/) to avoid the this default HASS integration's issues. To me, it seems more sensible to fix the unnecessary polling than try to work around the issues it causes.

The accessed fields `pmt` and `uptime` are supported since WLED 0.11.0 (November 2020 release).

## Related Issues

https://github.com/MoonModules/WLED-MM/issues/307
https://github.com/wled/WLED/issues/2480
https://github.com/home-assistant/core/issues/90676
https://github.com/home-assistant/core/issues/134863

A related potential future improvement has been described in the first issue https://github.com/MoonModules/WLED-MM/issues/307 . By adding ETag on WLED's output, client could avoid fetching /presets.json contents when it hasn't changed. This does not however solve the use-case of using `listen()` to detect Preset changes nor does it fix the issue for the existing fleet, which are the goals of this PR.

For completeness, an ETag implementation is provided in:  https://github.com/gunjambi/python-wled/pull/1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intelligent preset-change detection: device presets are checked and only refetched when a change is detected, reducing unnecessary network activity and improving sync.

* **Bug Fixes**
  * More robust handling of incomplete device info and websocket-driven preset updates; empty preset responses now surface a clear error.

* **Tests**
  * Added tests covering update/listen behaviors, caching, refetching, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->