### PR TITLE
Use orjson for request serialization to preserve unicode

### DIFF
--- a/src/wled/wled.py
+++ b/src/wled/wled.py
@@ -211,8 +211,10 @@ class WLED:
                 response = await self.session.request(
                     method,
                     url,
-                    json=data,
-                    headers=headers,
+                    data=orjson.dumps(data) if data is not None else None,
+                    headers=headers | {"Content-Type": "application/json"}
+                    if data is not None
+                    else headers,
                 )
 
             content_type = response.headers.get("Content-Type", "")


### PR DESCRIPTION
# Proposed Changes

Replace aiohttp's built-in json= parameter with `orjson.dumps()` for outgoing requests. `aiohttp` uses `stdlib` `json.dumps` which escapes non-ASCII characters to `\uXXXX` sequences, causing segment names with characters like éçà to be stored as escape sequences on the device. `orjson` (already a dependency) serializes to proper UTF-8 by default.

## Related Issues

Fixes #1683
