### PR TITLE
Add configurable repository for releases and upgrades

### DIFF
--- a/src/wled/const.py
+++ b/src/wled/const.py
@@ -4,6 +4,8 @@ from enum import IntEnum, IntFlag
 
 from awesomeversion import AwesomeVersion
 
+DEFAULT_REPO = "wled/WLED"
+
 MIN_REQUIRED_VERSION = AwesomeVersion("0.14.0")
 
 

--- a/src/wled/models.py
+++ b/src/wled/models.py
@@ -891,4 +891,5 @@ class Releases(BaseModel):
 
     beta: AwesomeVersion | None
     nightly: AwesomeVersion | None
+    repo: str
     stable: AwesomeVersion | None

--- a/src/wled/wled.py
+++ b/src/wled/wled.py
@@ -14,6 +14,7 @@ import backoff
 import orjson
 from yarl import URL
 
+from .const import DEFAULT_REPO
 from .exceptions import (
     WLEDConnectionClosedError,
     WLEDConnectionError,
@@ -601,12 +602,18 @@ class WLED:
         nightlight = {k: v for k, v in nightlight.items() if v is not None}
         await self.request("/json/state", method="POST", data={"nl": nightlight})
 
-    async def upgrade(self, *, version: str | AwesomeVersion) -> None:  # noqa: PLR0912
+    async def upgrade(  # noqa: PLR0912
+        self,
+        *,
+        version: str | AwesomeVersion,
+        repo: str = DEFAULT_REPO,
+    ) -> None:
         """Upgrade WLED device to the specified version.
 
         Args:
         ----
             version: The version to upgrade to.
+            repo: GitHub repository to download firmware from.
 
         Raises:
         ------
@@ -675,7 +682,7 @@ class WLED:
             architecture = self._device.info.architecture.upper()
             update_file = f"WLED_{version}_{architecture}{ethernet}.bin{gzip}"
         download_url = (
-            f"https://github.com/wled/WLED/releases/download/v{version}/{update_file}"
+            f"https://github.com/{repo}/releases/download/v{version}/{update_file}"
         )
 
         try:
@@ -791,6 +798,7 @@ class WLED:
 class WLEDReleases:
     """Get version information for WLED."""
 
+    repo: str = DEFAULT_REPO
     request_timeout: float = 8.0
     session: aiohttp.client.ClientSession | None = None
 
@@ -822,7 +830,7 @@ class WLEDReleases:
         try:
             async with asyncio.timeout(self.request_timeout):
                 response = await self.session.get(
-                    "https://api.github.com/repos/wled/WLED/releases",
+                    f"https://api.github.com/repos/{self.repo}/releases",
                     headers={"Accept": "application/json"},
                 )
         except TimeoutError as exception:
@@ -884,6 +892,7 @@ class WLEDReleases:
             {
                 "beta": version_beta or "",
                 "nightly": version_nightly or "",
+                "repo": self.repo,
                 "stable": version_stable or "",
             }
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,7 +85,9 @@ def _mock_releases(
     nightly: str = "17.0.0-dev20260416",
 ) -> MagicMock:
     """Create a mock WLEDReleases that returns the given versions."""
-    releases = Releases.from_dict({"stable": stable, "beta": beta, "nightly": nightly})
+    releases = Releases.from_dict(
+        {"stable": stable, "beta": beta, "nightly": nightly, "repo": "wled/WLED"}
+    )
     instance = AsyncMock()
     instance.__aenter__.return_value = instance
     instance.__aexit__.return_value = None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -805,16 +805,24 @@ def test_get_awesome_version_cached() -> None:
 def test_releases_from_dict() -> None:
     """Test Releases deserialization."""
     releases = Releases.from_dict(
-        {"stable": "0.14.0", "beta": "0.15.0b1", "nightly": "17.0.0-dev"}
+        {
+            "stable": "0.14.0",
+            "beta": "0.15.0b1",
+            "nightly": "17.0.0-dev",
+            "repo": "wled/WLED",
+        }
     )
     assert releases.stable is not None
     assert releases.beta is not None
     assert releases.nightly is not None
+    assert releases.repo == "wled/WLED"
 
 
 def test_releases_none_values() -> None:
     """Test Releases with None values."""
-    releases = Releases.from_dict({"stable": "", "beta": "", "nightly": ""})
+    releases = Releases.from_dict(
+        {"stable": "", "beta": "", "nightly": "", "repo": "wled/WLED"}
+    )
     assert releases.stable is None
     assert releases.beta is None
     assert releases.nightly is None

--- a/tests/test_wled.py
+++ b/tests/test_wled.py
@@ -1485,6 +1485,29 @@ async def test_releases_success() -> None:
             assert str(releases.beta) == "0.15.0b1"
             assert releases.nightly is not None
             assert str(releases.nightly) == "17.0.0-dev20260416"
+            assert releases.repo == "wled/WLED"
+
+
+async def test_releases_custom_repo() -> None:
+    """Test fetching releases from a custom repository."""
+    releases_data = [
+        {
+            "tag_name": "v0.14.0",
+            "prerelease": False,
+        },
+    ]
+    with aioresponses() as mocked:
+        mocked.get(
+            "https://api.github.com/repos/MoonModules/WLED/releases",
+            status=200,
+            body=json.dumps(releases_data),
+            content_type="application/json",
+        )
+        async with aiohttp.ClientSession() as session:
+            wled_releases = WLEDReleases(repo="MoonModules/WLED", session=session)
+            releases = await wled_releases.releases()
+            assert releases.repo == "MoonModules/WLED"
+            assert str(releases.stable) == "0.14.0"
 
 
 async def test_releases_with_b_in_tag_name() -> None:


### PR DESCRIPTION
# Proposed Changes

Allow specifying a custom GitHub repository for fetching releases and downloading firmware upgrades. This enables users running WLED forks (e.g. MoonModules/WLED) to check for updates and upgrade from their fork's releases.

- `WLEDReleases` accepts a repo parameter (defaults to `wled/WLED`)
- `upgrade()` accepts a repo parameter for the firmware download source
- `Releases` model includes the repo for reference by consumers

## Related Issues

Closes #1576
Closes #1597
