### PR TITLE
Add upgrade command to CLI

### DIFF
--- a/src/wled/cli/__init__.py
+++ b/src/wled/cli/__init__.py
@@ -310,6 +310,37 @@ async def command_reset(
     console.print("[green]WLED device has been rebooted!")
 
 
+@cli.command("upgrade")
+async def command_upgrade(
+    host: Annotated[
+        str,
+        typer.Option(
+            help="WLED device IP address or hostname",
+            prompt="Host address",
+            show_default=False,
+        ),
+    ],
+    version: Annotated[
+        str,
+        typer.Option(
+            help="WLED version to upgrade to",
+            prompt="Version",
+            show_default=False,
+        ),
+    ],
+) -> None:
+    """Upgrade a WLED device to a specific version."""
+    async with WLED(host) as led:
+        device = await led.update()
+        console.print(f"[cyan]Current version: [bold]{device.info.version}[/bold]")
+        console.print(f"[cyan]Upgrading to: [bold]{version}[/bold]")
+
+        with console.status("[cyan]Upgrading WLED device...", spinner="toggle12"):
+            await led.upgrade(version=version)
+
+    console.print("[green]Upgrade complete! The device will reboot.")
+
+
 @cli.command("scan")
 async def command_scan() -> None:
     """Scan for WLED devices on the network."""

--- a/tests/__snapshots__/test_cli.ambr
+++ b/tests/__snapshots__/test_cli.ambr
@@ -23,6 +23,10 @@
     ]),
     'scan': list([
     ]),
+    'upgrade': list([
+      'host',
+      'version',
+    ]),
   })
 # ---
 # name: test_connection_error_handler
@@ -286,6 +290,14 @@
   │     Currently only 0.14.0 and higher is supported                │
   │                                                                  │
   ╰──────────────────────────────────────────────────────────────────╯
+  
+  '''
+# ---
+# name: test_upgrade_command
+  '''
+  Current version: 0.14.0
+  Upgrading to: 0.15.0
+  Upgrade complete! The device will reboot.
   
   '''
 # ---

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -384,6 +384,22 @@ def test_reset_command(
 
 
 @pytest.mark.usefixtures("stable_terminal")
+def test_upgrade_command(
+    runner: CliRunner,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Upgrade command shows progress and completes."""
+    mock = _mock_wled(_device())
+    with patch("wled.cli.WLED", mock):
+        result = runner.invoke(
+            cli, ["upgrade", "--host", "example.com", "--version", "0.15.0"]
+        )
+    assert result.exit_code == 0
+    assert result.output == snapshot
+    mock.return_value.upgrade.assert_awaited_once_with(version="0.15.0")
+
+
+@pytest.mark.usefixtures("stable_terminal")
 def test_releases_command(
     runner: CliRunner,
     snapshot: SnapshotAssertion,


### PR DESCRIPTION
# Proposed Changes

Add a wled upgrade command to upgrade WLED device firmware from the command line

## Related Issues

> ([GitHub link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
