### PR TITLE
Add on, off, and brightness commands to CLI

### DIFF
--- a/src/wled/cli/__init__.py
+++ b/src/wled/cli/__init__.py
@@ -64,6 +64,67 @@ def unsupported_version_error_handler(
     sys.exit(1)
 
 
+@cli.command("on")
+async def command_on(
+    host: Annotated[
+        str,
+        typer.Option(
+            help="WLED device IP address or hostname",
+            prompt="Host address",
+            show_default=False,
+        ),
+    ],
+) -> None:
+    """Turn on a WLED device."""
+    async with WLED(host) as led:
+        await led.master(on=True)
+    console.print("[green]WLED device turned on!")
+
+
+@cli.command("off")
+async def command_off(
+    host: Annotated[
+        str,
+        typer.Option(
+            help="WLED device IP address or hostname",
+            prompt="Host address",
+            show_default=False,
+        ),
+    ],
+) -> None:
+    """Turn off a WLED device."""
+    async with WLED(host) as led:
+        await led.master(on=False)
+    console.print("[green]WLED device turned off!")
+
+
+@cli.command("brightness")
+async def command_brightness(
+    host: Annotated[
+        str,
+        typer.Option(
+            help="WLED device IP address or hostname",
+            prompt="Host address",
+            show_default=False,
+        ),
+    ],
+    brightness: Annotated[
+        int,
+        typer.Option(
+            help="Brightness level (0-255)",
+            prompt="Brightness",
+            show_default=False,
+            min=0,
+            max=255,
+        ),
+    ],
+) -> None:
+    """Set the brightness of a WLED device."""
+    async with WLED(host) as led:
+        await led.master(brightness=brightness)
+    console.print(f"[green]Brightness set to {brightness}!")
+
+
 @cli.command("info")
 async def command_info(
     host: Annotated[

--- a/tests/__snapshots__/test_cli.ambr
+++ b/tests/__snapshots__/test_cli.ambr
@@ -1,10 +1,26 @@
 # serializer version: 1
+# name: test_brightness_command
+  '''
+  Brightness set to 200!
+  
+  '''
+# ---
 # name: test_cli_structure
   dict({
+    'brightness': list([
+      'brightness',
+      'host',
+    ]),
     'effects': list([
       'host',
     ]),
     'info': list([
+      'host',
+    ]),
+    'off': list([
+      'host',
+    ]),
+    'on': list([
       'host',
     ]),
     'palettes': list([
@@ -191,6 +207,18 @@
   │ LED power             │ 0 mA              │
   │ LED max power         │ 850 mA            │
   └───────────────────────┴───────────────────┘
+  
+  '''
+# ---
+# name: test_off_command
+  '''
+  WLED device turned off!
+  
+  '''
+# ---
+# name: test_on_command
+  '''
+  WLED device turned on!
   
   '''
 # ---

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -263,6 +263,50 @@ def test_cli_structure(snapshot: SnapshotAssertion) -> None:
 
 
 @pytest.mark.usefixtures("stable_terminal")
+def test_on_command(
+    runner: CliRunner,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """On command turns on the device."""
+    mock = _mock_wled(_device())
+    with patch("wled.cli.WLED", mock):
+        result = runner.invoke(cli, ["on", "--host", "example.com"])
+    assert result.exit_code == 0
+    assert result.output == snapshot
+    mock.return_value.master.assert_awaited_once_with(on=True)
+
+
+@pytest.mark.usefixtures("stable_terminal")
+def test_off_command(
+    runner: CliRunner,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Off command turns off the device."""
+    mock = _mock_wled(_device())
+    with patch("wled.cli.WLED", mock):
+        result = runner.invoke(cli, ["off", "--host", "example.com"])
+    assert result.exit_code == 0
+    assert result.output == snapshot
+    mock.return_value.master.assert_awaited_once_with(on=False)
+
+
+@pytest.mark.usefixtures("stable_terminal")
+def test_brightness_command(
+    runner: CliRunner,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Brightness command sets device brightness."""
+    mock = _mock_wled(_device())
+    with patch("wled.cli.WLED", mock):
+        result = runner.invoke(
+            cli, ["brightness", "--host", "example.com", "--brightness", "200"]
+        )
+    assert result.exit_code == 0
+    assert result.output == snapshot
+    mock.return_value.master.assert_awaited_once_with(brightness=200)
+
+
+@pytest.mark.usefixtures("stable_terminal")
 def test_info_command(
     runner: CliRunner,
     snapshot: SnapshotAssertion,


### PR DESCRIPTION
# Proposed Changes

Add wled on, wled off, and wled brightness commands for basic device control.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `on` command to turn WLED devices on
  * Added `off` command to turn WLED devices off
  * Added `brightness` command to control device brightness (0-255 range)
  * All commands require specifying the device host (IP address or hostname)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->