### PR TITLE
Add preset and playlist commands to CLI

### DIFF
--- a/src/wled/cli/__init__.py
+++ b/src/wled/cli/__init__.py
@@ -317,6 +317,58 @@ async def command_presets(
     console.print(table)
 
 
+@cli.command("preset")
+async def command_preset(
+    host: Annotated[
+        str,
+        typer.Option(
+            help="WLED device IP address or hostname",
+            prompt="Host address",
+            show_default=False,
+        ),
+    ],
+    preset: Annotated[
+        str,
+        typer.Option(
+            help="Preset name or ID to activate",
+            prompt="Preset",
+            show_default=False,
+        ),
+    ],
+) -> None:
+    """Activate a preset on the WLED device."""
+    async with WLED(host) as led:
+        await led.update()
+        await led.preset(preset if not preset.isdigit() else int(preset))
+    console.print(f"[green]Preset '{preset}' activated!")
+
+
+@cli.command("playlist")
+async def command_playlist(
+    host: Annotated[
+        str,
+        typer.Option(
+            help="WLED device IP address or hostname",
+            prompt="Host address",
+            show_default=False,
+        ),
+    ],
+    playlist: Annotated[
+        str,
+        typer.Option(
+            help="Playlist name or ID to activate",
+            prompt="Playlist",
+            show_default=False,
+        ),
+    ],
+) -> None:
+    """Activate a playlist on the WLED device."""
+    async with WLED(host) as led:
+        await led.update()
+        await led.playlist(playlist if not playlist.isdigit() else int(playlist))
+    console.print(f"[green]Playlist '{playlist}' activated!")
+
+
 @cli.command("releases")
 async def command_releases() -> None:
     """Show the latest release information of WLED."""

--- a/tests/__snapshots__/test_cli.ambr
+++ b/tests/__snapshots__/test_cli.ambr
@@ -26,8 +26,16 @@
     'palettes': list([
       'host',
     ]),
+    'playlist': list([
+      'host',
+      'playlist',
+    ]),
     'playlists': list([
       'host',
+    ]),
+    'preset': list([
+      'host',
+      'preset',
     ]),
     'presets': list([
       'host',
@@ -237,6 +245,18 @@
   
   '''
 # ---
+# name: test_playlist_command_by_id
+  '''
+  Playlist '2' activated!
+  
+  '''
+# ---
+# name: test_playlist_command_by_name
+  '''
+  Playlist 'My Playlist' activated!
+  
+  '''
+# ---
 # name: test_playlists_command
   '''
                  
@@ -252,6 +272,18 @@
 # name: test_playlists_command_empty
   '''
   🚫 This device has no playlists
+  
+  '''
+# ---
+# name: test_preset_command_by_id
+  '''
+  Preset '1' activated!
+  
+  '''
+# ---
+# name: test_preset_command_by_name
+  '''
+  Preset 'My Preset' activated!
   
   '''
 # ---

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -439,6 +439,70 @@ def test_state_command(
 
 
 @pytest.mark.usefixtures("stable_terminal")
+def test_preset_command_by_name(
+    runner: CliRunner,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Preset command activates a preset by name."""
+    mock = _mock_wled(_device())
+    with patch("wled.cli.WLED", mock):
+        result = runner.invoke(
+            cli, ["preset", "--host", "example.com", "--preset", "My Preset"]
+        )
+    assert result.exit_code == 0
+    assert result.output == snapshot
+    mock.return_value.preset.assert_awaited_once_with("My Preset")
+
+
+@pytest.mark.usefixtures("stable_terminal")
+def test_preset_command_by_id(
+    runner: CliRunner,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Preset command activates a preset by numeric ID."""
+    mock = _mock_wled(_device())
+    with patch("wled.cli.WLED", mock):
+        result = runner.invoke(
+            cli, ["preset", "--host", "example.com", "--preset", "1"]
+        )
+    assert result.exit_code == 0
+    assert result.output == snapshot
+    mock.return_value.preset.assert_awaited_once_with(1)
+
+
+@pytest.mark.usefixtures("stable_terminal")
+def test_playlist_command_by_name(
+    runner: CliRunner,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Playlist command activates a playlist by name."""
+    mock = _mock_wled(_device())
+    with patch("wled.cli.WLED", mock):
+        result = runner.invoke(
+            cli, ["playlist", "--host", "example.com", "--playlist", "My Playlist"]
+        )
+    assert result.exit_code == 0
+    assert result.output == snapshot
+    mock.return_value.playlist.assert_awaited_once_with("My Playlist")
+
+
+@pytest.mark.usefixtures("stable_terminal")
+def test_playlist_command_by_id(
+    runner: CliRunner,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Playlist command activates a playlist by numeric ID."""
+    mock = _mock_wled(_device())
+    with patch("wled.cli.WLED", mock):
+        result = runner.invoke(
+            cli, ["playlist", "--host", "example.com", "--playlist", "2"]
+        )
+    assert result.exit_code == 0
+    assert result.output == snapshot
+    mock.return_value.playlist.assert_awaited_once_with(2)
+
+
+@pytest.mark.usefixtures("stable_terminal")
 def test_upgrade_command(
     runner: CliRunner,
     snapshot: SnapshotAssertion,


### PR DESCRIPTION
# Proposed Changes

Add wled preset and wled playlist commands to activate a preset or playlist by name or ID
