### PR TITLE
Fix install command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ To install all packages, including all development requirements:
 
 ```bash
 npm install
-poetry install
+poetry install --all-extras
 ```
 
 As this repository uses the [prek][prek] framework, all changes


### PR DESCRIPTION
# Proposed Changes

We need to install `cli` extras to run all tests.

Without CLI extras, tests failed with the following error:
```
_________________________________________________________________________________________ ERROR collecting tests/test_cli.py _________________________________________________________________________________________
ImportError while importing test module '/Users/kamil/devel/smart-home/home-assistant/python-wled/tests/test_cli.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../../.pyenv/versions/3.14.0/lib/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/test_cli.py:17: in <module>
    from wled.cli import cli
src/wled/cli/__init__.py:12: in <module>
    from zeroconf import ServiceStateChange, Zeroconf
E   ModuleNotFoundError: No module named 'zeroconf'
```
> (Describe the changes and rationale behind them)

## Related Issues

> ([GitHub link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development setup instructions to install additional optional dependencies when configuring the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->