### PR TITLE
Handle non-UTF-8 and invalid JSON responses from WLED device

### DIFF
--- a/src/wled/__init__.py
+++ b/src/wled/__init__.py
@@ -13,6 +13,7 @@ from .exceptions import (
     WLEDConnectionTimeoutError,
     WLEDEmptyResponseError,
     WLEDError,
+    WLEDInvalidResponseError,
     WLEDUnsupportedVersionError,
     WLEDUpgradeError,
 )
@@ -63,6 +64,7 @@ __all__ = [
     "WLEDConnectionTimeoutError",
     "WLEDEmptyResponseError",
     "WLEDError",
+    "WLEDInvalidResponseError",
     "WLEDReleases",
     "WLEDUnsupportedVersionError",
     "WLEDUpgradeError",

--- a/src/wled/exceptions.py
+++ b/src/wled/exceptions.py
@@ -9,6 +9,10 @@ class WLEDEmptyResponseError(Exception):
     """WLED empty API response exception."""
 
 
+class WLEDInvalidResponseError(WLEDError):
+    """WLED invalid API response exception."""
+
+
 class WLEDConnectionError(WLEDError):
     """WLED connection exception."""
 

--- a/src/wled/wled.py
+++ b/src/wled/wled.py
@@ -224,14 +224,27 @@ class WLED:
                 contents = await response.read()
                 response.close()
 
-                if content_type == "application/json":
-                    raise WLEDError(
-                        response.status,
-                        orjson.loads(contents),
+                if "application/json" in content_type:
+                    try:
+                        error_body = orjson.loads(contents)
+                    except orjson.JSONDecodeError as exception:
+                        msg = (
+                            "Received an invalid JSON error response "
+                            f"from request: {method} {uri}"
+                        )
+                        raise WLEDInvalidResponseError(msg) from exception
+                    raise WLEDError(response.status, error_body)
+                try:
+                    message = contents.decode("utf-8")
+                except UnicodeDecodeError as exception:
+                    msg = (
+                        "Received a non-UTF-8 error response "
+                        f"from request: {method} {uri}"
                     )
+                    raise WLEDInvalidResponseError(msg) from exception
                 raise WLEDError(
                     response.status,
-                    {"message": contents.decode("utf8")},
+                    {"message": message},
                 )
 
             try:

--- a/src/wled/wled.py
+++ b/src/wled/wled.py
@@ -21,6 +21,7 @@ from .exceptions import (
     WLEDConnectionTimeoutError,
     WLEDEmptyResponseError,
     WLEDError,
+    WLEDInvalidResponseError,
     WLEDUpgradeError,
 )
 from .models import Device, Playlist, Preset, Releases
@@ -233,10 +234,20 @@ class WLED:
                     {"message": contents.decode("utf8")},
                 )
 
-            response_data = await response.text()
+            try:
+                response_data = await response.text()
+            except UnicodeDecodeError as exception:
+                msg = f"Received a non-UTF-8 response from request: {method} {uri}"
+                raise WLEDInvalidResponseError(msg) from exception
             if "application/json" in content_type:
-                response_data = orjson.loads(response_data)
-
+                try:
+                    response_data = orjson.loads(response_data)
+                except orjson.JSONDecodeError as exception:
+                    msg = (
+                        "Received an invalid JSON response "
+                        f"from request: {method} {uri}"
+                    )
+                    raise WLEDInvalidResponseError(msg) from exception
         except TimeoutError as exception:
             msg = f"Timeout occurred while connecting to WLED device at {self.host}"
             raise WLEDConnectionTimeoutError(msg) from exception

--- a/tests/test_wled.py
+++ b/tests/test_wled.py
@@ -195,24 +195,26 @@ async def test_update_empty_json_response(responses: aioresponses, wled: WLED) -
         await wled.update()
 
 
-async def test_update_invalid_json_response(
-    responses: aioresponses, wled: WLED
+@pytest.mark.parametrize("body", ["AAAA", b"\xff\xfe"])
+async def test_update_corrupt_json_response(
+    responses: aioresponses, wled: WLED, body: str | bytes
 ) -> None:
-    """Test update() raises on invalid /json response."""
+    """Test update() raises on corrupt (invalid JSON or non-UTF-8) /json response."""
     responses.get(
         "http://example.com/json",
         status=200,
-        body="AAAA",
+        body=body,
         content_type="application/json",
     )
     with pytest.raises(WLEDInvalidResponseError):
         await wled.update()
 
 
-async def test_update_invalid_presets_response(
-    responses: aioresponses, wled: WLED
+@pytest.mark.parametrize("body", ["AAAA", b"\xff\xfe"])
+async def test_update_corrupt_presets_response(
+    responses: aioresponses, wled: WLED, body: str | bytes
 ) -> None:
-    """Test update() raises on invalid /presets.json response."""
+    """Test update() raises on corrupt /presets.json response."""
     wled_data = load_fixture_json("wled")
     responses.get(
         "http://example.com/json",
@@ -223,44 +225,7 @@ async def test_update_invalid_presets_response(
     responses.get(
         "http://example.com/presets.json",
         status=200,
-        body="AAAA",
-        content_type="application/json",
-    )
-    with pytest.raises(WLEDInvalidResponseError):
-        await wled.update()
-
-
-async def test_update_non_utf8_json_response(
-    responses: aioresponses,
-    wled: WLED,
-) -> None:
-    """Test update() raises on non-UTF-8 /json response."""
-    responses.get(
-        "http://example.com/json",
-        status=200,
-        body=b"\xff\xfe",
-        content_type="application/json",
-    )
-    with pytest.raises(WLEDInvalidResponseError):
-        await wled.update()
-
-
-async def test_update_non_utf8_presets_response(
-    responses: aioresponses,
-    wled: WLED,
-) -> None:
-    """Test update() raises on non-UTF-8 /presets.json response."""
-    wled_data = load_fixture_json("wled")
-    responses.get(
-        "http://example.com/json",
-        status=200,
-        body=json.dumps(wled_data),
-        content_type="application/json",
-    )
-    responses.get(
-        "http://example.com/presets.json",
-        status=200,
-        body=b"\xff\xfe",
+        body=body,
         content_type="application/json",
     )
     with pytest.raises(WLEDInvalidResponseError):

--- a/tests/test_wled.py
+++ b/tests/test_wled.py
@@ -19,6 +19,7 @@ from wled.exceptions import (
     WLEDConnectionTimeoutError,
     WLEDEmptyResponseError,
     WLEDError,
+    WLEDInvalidResponseError,
     WLEDUpgradeError,
 )
 from wled.wled import WLEDReleases
@@ -191,6 +192,78 @@ async def test_update_empty_json_response(responses: aioresponses, wled: WLED) -
         )
 
     with pytest.raises(WLEDEmptyResponseError):
+        await wled.update()
+
+
+async def test_update_invalid_json_response(
+    responses: aioresponses, wled: WLED
+) -> None:
+    """Test update() raises on invalid /json response."""
+    responses.get(
+        "http://example.com/json",
+        status=200,
+        body="AAAA",
+        content_type="application/json",
+    )
+    with pytest.raises(WLEDInvalidResponseError):
+        await wled.update()
+
+
+async def test_update_invalid_presets_response(
+    responses: aioresponses, wled: WLED
+) -> None:
+    """Test update() raises on invalid /presets.json response."""
+    wled_data = load_fixture_json("wled")
+    responses.get(
+        "http://example.com/json",
+        status=200,
+        body=json.dumps(wled_data),
+        content_type="application/json",
+    )
+    responses.get(
+        "http://example.com/presets.json",
+        status=200,
+        body="AAAA",
+        content_type="application/json",
+    )
+    with pytest.raises(WLEDInvalidResponseError):
+        await wled.update()
+
+
+async def test_update_non_utf8_json_response(
+    responses: aioresponses,
+    wled: WLED,
+) -> None:
+    """Test update() raises on non-UTF-8 /json response."""
+    responses.get(
+        "http://example.com/json",
+        status=200,
+        body=b"\xff\xfe",
+        content_type="application/json",
+    )
+    with pytest.raises(WLEDInvalidResponseError):
+        await wled.update()
+
+
+async def test_update_non_utf8_presets_response(
+    responses: aioresponses,
+    wled: WLED,
+) -> None:
+    """Test update() raises on non-UTF-8 /presets.json response."""
+    wled_data = load_fixture_json("wled")
+    responses.get(
+        "http://example.com/json",
+        status=200,
+        body=json.dumps(wled_data),
+        content_type="application/json",
+    )
+    responses.get(
+        "http://example.com/presets.json",
+        status=200,
+        body=b"\xff\xfe",
+        content_type="application/json",
+    )
+    with pytest.raises(WLEDInvalidResponseError):
         await wled.update()
 
 

--- a/tests/test_wled.py
+++ b/tests/test_wled.py
@@ -153,6 +153,27 @@ async def test_http_error500(responses: aioresponses, wled: WLED) -> None:
         assert await wled.request("/")
 
 
+@pytest.mark.parametrize(
+    ("body", "content_type"),
+    [
+        (b"\xff\xfe", "text/plain"),
+        (b"not-json", "application/json"),
+    ],
+)
+async def test_http_error_invalid_response(
+    responses: aioresponses, wled: WLED, body: bytes, content_type: str
+) -> None:
+    """Test HTTP error with unparsable body raises WLEDInvalidResponseError."""
+    responses.get(
+        "http://example.com/",
+        status=500,
+        body=body,
+        content_type=content_type,
+    )
+    with pytest.raises(WLEDInvalidResponseError, match=r"GET /"):
+        await wled.request("/")
+
+
 # =========================================================================
 # Section 10: WLED client - update() method
 # =========================================================================
@@ -206,7 +227,7 @@ async def test_update_corrupt_json_response(
         body=body,
         content_type="application/json",
     )
-    with pytest.raises(WLEDInvalidResponseError):
+    with pytest.raises(WLEDInvalidResponseError, match=r"GET /json"):
         await wled.update()
 
 
@@ -228,7 +249,7 @@ async def test_update_corrupt_presets_response(
         body=body,
         content_type="application/json",
     )
-    with pytest.raises(WLEDInvalidResponseError):
+    with pytest.raises(WLEDInvalidResponseError, match=r"GET /presets\.json"):
         await wled.update()
 
 


### PR DESCRIPTION
# Proposed Changes

Some WLED devices can return corrupt data that causes an unhandled exception in the integration, silently presenting the user with a generic "Failed to connect" or "An unknown error occurred" message with no diagnostic information in the logs.

Two concrete failure modes observed in the wild ( https://github.com/home-assistant/core/issues/162199
 ):

1. **Corrupt `presets.json`** — the device returns binary garbage (e.g. bytes starting with `\xff\xfe`), which causes `response.text()` to raise `UnicodeDecodeError` before any JSON parsing takes place.
2. **Invalid JSON** — the device returns a response with `Content-Type: application/json` but the body is not valid JSON, causing `orjson.loads()` to raise `JSONDecodeError`.

Both exceptions were previously unhandled and propagated as unexpected errors. This change catches them explicitly and raises `WLEDInvalidResponseError` (a new exception class) with a message that includes the HTTP method and URI, making it straightforward to identify the problematic endpoint in logs.

**Changes:**
- Add `WLEDInvalidResponseError(WLEDError)` to `exceptions.py`
- Wrap `response.text()` in a `try/except UnicodeDecodeError`
- Wrap `orjson.loads()` in a `try/except orjson.JSONDecodeError`
- Add tests for all four new error paths (`/json` and `/presets.json` × non-UTF-8 and invalid JSON)

**References:** home-assistant/core#162199

## Related Issues

