### PR TITLE
Replace discontinued devcontainers-contrib with devcontainers-extra

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,7 +40,7 @@
     }
   },
   "features": {
-    "ghcr.io/devcontainers-contrib/features/poetry:2": {},
+    "ghcr.io/devcontainers-extra/features/poetry:2.0.18": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/node:1": {},
     "ghcr.io/devcontainers/features/python:1": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,7 +40,7 @@
     }
   },
   "features": {
-    "ghcr.io/devcontainers-extra/features/poetry:2.0.18": {},
+    "ghcr.io/devcontainers-extra/features/poetry:2": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/node:1": {},
     "ghcr.io/devcontainers/features/python:1": {


### PR DESCRIPTION

Visual Studio doesn't like old feature
<img width="900" height="155" alt="Screenshot 2026-05-12 at 01 52 20" src="https://github.com/user-attachments/assets/28550660-0ed8-446e-beab-98bd7a8c1b21" />

Dependabot too.
<img width="1581" height="272" alt="Screenshot 2026-05-12 at 02 00 27" src="https://github.com/user-attachments/assets/10ee3598-2906-4f29-b817-a491249fd160" />


# Proposed Changes

> (Describe the changes and rationale behind them)

## Related Issues

> ([GitHub link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development environment to use the Poetry feature v2.0.18 container image.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frenck/python-wled/pull/2062)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->