### PR TITLE
Replace asyncio.iscoroutinefunction with inspect.iscoroutinefunction

### DIFF
--- a/src/wled/cli/async_typer.py
+++ b/src/wled/cli/async_typer.py
@@ -22,6 +22,7 @@ Adaptation of the snippet/code from:
 from __future__ import annotations
 
 import asyncio
+import inspect
 from collections.abc import Callable
 from functools import wraps
 from typing import (
@@ -96,7 +97,7 @@ class AsyncTyper(SyncTyper):
         def decorator(
             func: Callable[_P, Coroutine[Any, Any, _R]],
         ) -> Callable[_P, Coroutine[Any, Any, _R]]:
-            if asyncio.iscoroutinefunction(func):
+            if inspect.iscoroutinefunction(func):
 
                 @wraps(func)
                 def sync_func(*_args: _P.args, **_kwargs: _P.kwargs) -> _R:
@@ -151,7 +152,7 @@ class AsyncTyper(SyncTyper):
         def decorator(
             func: Callable[_P, Coroutine[Any, Any, _R]],
         ) -> Callable[_P, Coroutine[Any, Any, _R]]:
-            if asyncio.iscoroutinefunction(func):
+            if inspect.iscoroutinefunction(func):
 
                 @wraps(func)
                 def sync_func(*_args: _P.args, **_kwargs: _P.kwargs) -> _R:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@
 # pylint: disable=redefined-outer-name
 from __future__ import annotations
 
-import asyncio
+import inspect
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -120,7 +120,7 @@ def test_async_typer_command_wraps_async() -> None:
     async def greet() -> None:
         pass
 
-    assert asyncio.iscoroutinefunction(greet)
+    assert inspect.iscoroutinefunction(greet)
 
 
 def test_async_typer_command_wraps_sync() -> None:
@@ -131,7 +131,7 @@ def test_async_typer_command_wraps_sync() -> None:
     def greet() -> None:
         pass
 
-    assert not asyncio.iscoroutinefunction(greet)
+    assert not inspect.iscoroutinefunction(greet)
 
 
 def test_async_typer_callback_wraps_async() -> None:
@@ -142,7 +142,7 @@ def test_async_typer_callback_wraps_async() -> None:
     async def main() -> None:
         pass
 
-    assert asyncio.iscoroutinefunction(main)
+    assert inspect.iscoroutinefunction(main)
 
 
 def test_async_typer_callback_wraps_sync() -> None:
@@ -153,7 +153,7 @@ def test_async_typer_callback_wraps_sync() -> None:
     def main() -> None:
         pass
 
-    assert not asyncio.iscoroutinefunction(main)
+    assert not inspect.iscoroutinefunction(main)
 
 
 def test_async_typer_error_handler_registered() -> None:


### PR DESCRIPTION
## Summary
Replace deprecated `asyncio.iscoroutinefunction()` with `inspect.iscoroutinefunction()` to address Python 3.16 deprecation warnings.

## Changes
- Updated async_typer.py to use inspect.iscoroutinefunction()
- Updated test_cli.py to use inspect.iscoroutinefunction() and removed unused asyncio import

## Test plan
- All pre-commit hooks pass
- All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Internal improvements to CLI command detection logic to enhance code reliability and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frenck/python-wled/pull/2066?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->