### PR TITLE
ci: add pytest job for minimum dependency versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,6 +48,28 @@ jobs:
           include-hidden-files: true
           path: .coverage
 
+  pytest-min-deps:
+    name: Python ${{ env.DEFAULT_PYTHON }} (minimum dependencies)
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: 🏗 Set up Python ${{ env.DEFAULT_PYTHON }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+      - name: 🏗 Install uv
+        run: pipx install uv
+      - name: 🏗 Install dependencies (minimum versions)
+        run: >
+          uv pip install --system --resolution=lowest-direct
+          -e ".[cli]"
+          aioresponses pytest pytest-asyncio pytest-cov covdefaults syrupy
+      - name: 🚀 Run pytest
+        run: pytest tests
+
   coverage:
     runs-on: ubuntu-latest
     needs: pytest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: 🏗 Install package (minimum dependency versions)
         run: uv pip install --system --resolution=lowest-direct -e ".[cli]"
       - name: 🏗 Install test dependencies
-        run: uv pip install --system aioresponses pytest pytest-asyncio syrupy
+        run: uv pip install --system aioresponses pytest pytest-asyncio pytest-cov syrupy
       - name: 🚀 Run pytest
         run: pytest tests --no-cov
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -62,13 +62,12 @@ jobs:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: 🏗 Install uv
         run: pipx install uv
-      - name: 🏗 Install dependencies (minimum versions)
-        run: >
-          uv pip install --system --resolution=lowest-direct
-          -e ".[cli]"
-          aioresponses pytest pytest-asyncio pytest-cov covdefaults syrupy
+      - name: 🏗 Install package (minimum dependency versions)
+        run: uv pip install --system --resolution=lowest-direct -e ".[cli]"
+      - name: 🏗 Install test dependencies
+        run: uv pip install --system aioresponses pytest pytest-asyncio syrupy
       - name: 🚀 Run pytest
-        run: pytest tests
+        run: pytest tests --no-cov
 
   coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a new CI job `pytest-min-deps` that verifies the library works with the lowest allowed versions of its direct dependencies, as declared in `pyproject.toml`.

## Motivation

The existing CI always installs the latest compatible dependency versions via `poetry install`. This means the declared minimum version bounds (e.g. `aiohttp>=3.0.0`, `yarl>=1.6.0`) were never actually tested — the library could be incompatible with its own declared minimums without anyone noticing.

Related to #2072.

## How it works

Uses `uv pip install --resolution=lowest-direct`, which automatically resolves to the lowest allowed version of each direct dependency. The job runs on Python 3.11 (the oldest supported version) and is independent from the coverage pipeline.

---
*Generated by GitHub Copilot in VS Agent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI adds a new test job that installs the project with minimum direct dependency versions and runs the test suite without coverage.
  * Existing test and coverage workflows remain unchanged; coverage still depends on the original test run.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frenck/python-wled/pull/2080?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->