### PR TITLE
Improve exception hierarchy with structured method/path/status attributes

### DIFF
--- a/src/wled/__init__.py
+++ b/src/wled/__init__.py
@@ -14,6 +14,8 @@ from .exceptions import (
     WLEDEmptyResponseError,
     WLEDError,
     WLEDInvalidResponseError,
+    WLEDResponseError,
+    WLEDStatusError,
     WLEDUnsupportedVersionError,
     WLEDUpgradeError,
 )
@@ -66,6 +68,8 @@ __all__ = [
     "WLEDError",
     "WLEDInvalidResponseError",
     "WLEDReleases",
+    "WLEDResponseError",
+    "WLEDStatusError",
     "WLEDUnsupportedVersionError",
     "WLEDUpgradeError",
     "Wifi",

--- a/src/wled/exceptions.py
+++ b/src/wled/exceptions.py
@@ -10,7 +10,7 @@ class WLEDEmptyResponseError(WLEDError):
 
     def __init__(
         self,
-        message: str,
+        message: str = "",
         *,
         method: str | None = None,
         path: str | None = None,
@@ -26,7 +26,7 @@ class WLEDInvalidResponseError(WLEDError):
 
     def __init__(
         self,
-        message: str,
+        message: str = "",
         *,
         method: str | None = None,
         path: str | None = None,

--- a/src/wled/exceptions.py
+++ b/src/wled/exceptions.py
@@ -5,38 +5,6 @@ class WLEDError(Exception):
     """Generic WLED exception."""
 
 
-class WLEDEmptyResponseError(WLEDError):
-    """WLED empty API response exception."""
-
-    def __init__(
-        self,
-        message: str = "",
-        *,
-        method: str | None = None,
-        path: str | None = None,
-    ) -> None:
-        """Initialize WLEDEmptyResponseError."""
-        super().__init__(message)
-        self.method = method
-        self.path = path
-
-
-class WLEDInvalidResponseError(WLEDError):
-    """WLED invalid API response exception."""
-
-    def __init__(
-        self,
-        message: str = "",
-        *,
-        method: str | None = None,
-        path: str | None = None,
-    ) -> None:
-        """Initialize WLEDInvalidResponseError."""
-        super().__init__(message)
-        self.method = method
-        self.path = path
-
-
 class WLEDConnectionError(WLEDError):
     """WLED connection exception."""
 
@@ -47,6 +15,48 @@ class WLEDConnectionTimeoutError(WLEDConnectionError):
 
 class WLEDConnectionClosedError(WLEDConnectionError):
     """WLED WebSocket connection has been closed."""
+
+
+class WLEDStatusError(WLEDError):
+    """WLED HTTP status error exception (4xx/5xx status codes)."""
+
+    def __init__(
+        self,
+        *args: object,
+        method: str | None = None,
+        path: str | None = None,
+        status: int | None = None,
+        body: object = None,
+    ) -> None:
+        """Initialize WLEDStatusError."""
+        super().__init__(*args)
+        self.method = method
+        self.path = path
+        self.status = status
+        self.body = body
+
+
+class WLEDResponseError(WLEDError):
+    """WLED response error exception."""
+
+    def __init__(
+        self,
+        *args: object,
+        method: str | None = None,
+        path: str | None = None,
+    ) -> None:
+        """Initialize WLEDResponseError."""
+        super().__init__(*args)
+        self.method = method
+        self.path = path
+
+
+class WLEDEmptyResponseError(WLEDResponseError):
+    """WLED empty API response exception."""
+
+
+class WLEDInvalidResponseError(WLEDResponseError):
+    """WLED invalid API response exception."""
 
 
 class WLEDUnsupportedVersionError(WLEDError):

--- a/src/wled/exceptions.py
+++ b/src/wled/exceptions.py
@@ -5,12 +5,36 @@ class WLEDError(Exception):
     """Generic WLED exception."""
 
 
-class WLEDEmptyResponseError(Exception):
+class WLEDEmptyResponseError(WLEDError):
     """WLED empty API response exception."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        method: str | None = None,
+        path: str | None = None,
+    ) -> None:
+        """Initialize WLEDEmptyResponseError."""
+        super().__init__(message)
+        self.method = method
+        self.path = path
 
 
 class WLEDInvalidResponseError(WLEDError):
     """WLED invalid API response exception."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        method: str | None = None,
+        path: str | None = None,
+    ) -> None:
+        """Initialize WLEDInvalidResponseError."""
+        super().__init__(message)
+        self.method = method
+        self.path = path
 
 
 class WLEDConnectionError(WLEDError):

--- a/src/wled/wled.py
+++ b/src/wled/wled.py
@@ -243,7 +243,12 @@ class WLED:
                             msg, method=method, path=uri
                         ) from exception
                     raise WLEDStatusError(
-                        method=method, path=uri, status=response.status, body=error_body
+                        response.status,
+                        error_body,
+                        method=method,
+                        path=uri,
+                        status=response.status,
+                        body=error_body,
                     )
                 try:
                     message = contents.decode("utf-8")
@@ -256,6 +261,8 @@ class WLED:
                         msg, method=method, path=uri
                     ) from exception
                 raise WLEDStatusError(
+                    response.status,
+                    {"message": message},
                     method=method,
                     path=uri,
                     status=response.status,

--- a/src/wled/wled.py
+++ b/src/wled/wled.py
@@ -123,6 +123,8 @@ class WLED:
                 when fetching presets.
             WLEDInvalidResponseError: The WLED device returned an invalid response
                 when fetching presets.
+            WLEDStatusError: The WLED device returned a 4xx/5xx HTTP status
+                when fetching presets.
 
         """
         if not self._client or not self.connected or not self._device:
@@ -324,6 +326,7 @@ class WLED:
         ------
             WLEDEmptyResponseError: The WLED device returned an empty response.
             WLEDInvalidResponseError: The WLED device returned an invalid response.
+            WLEDStatusError: The WLED device returned a 4xx/5xx HTTP status.
 
         """
         if not (data := await self.request("/json")):

--- a/src/wled/wled.py
+++ b/src/wled/wled.py
@@ -22,6 +22,7 @@ from .exceptions import (
     WLEDEmptyResponseError,
     WLEDError,
     WLEDInvalidResponseError,
+    WLEDStatusError,
     WLEDUpgradeError,
 )
 from .models import Device, Playlist, Preset, Releases
@@ -241,7 +242,9 @@ class WLED:
                         raise WLEDInvalidResponseError(
                             msg, method=method, path=uri
                         ) from exception
-                    raise WLEDError(response.status, error_body)
+                    raise WLEDStatusError(
+                        method=method, path=uri, status=response.status, body=error_body
+                    )
                 try:
                     message = contents.decode("utf-8")
                 except UnicodeDecodeError as exception:
@@ -252,9 +255,11 @@ class WLED:
                     raise WLEDInvalidResponseError(
                         msg, method=method, path=uri
                     ) from exception
-                raise WLEDError(
-                    response.status,
-                    {"message": message},
+                raise WLEDStatusError(
+                    method=method,
+                    path=uri,
+                    status=response.status,
+                    body={"message": message},
                 )
 
             try:

--- a/src/wled/wled.py
+++ b/src/wled/wled.py
@@ -118,6 +118,10 @@ class WLED:
                 to the WLED device.
             WLEDConnectionClosedError: The WebSocket connection to the remote WLED
                 has been closed.
+            WLEDEmptyResponseError: The WLED device returned an empty response
+                when fetching presets.
+            WLEDInvalidResponseError: The WLED device returned an invalid response
+                when fetching presets.
 
         """
         if not self._client or not self.connected or not self._device:
@@ -138,9 +142,11 @@ class WLED:
                     if not (presets := await self.request("/presets.json")):
                         msg = (
                             f"WLED device at {self.host} returned an empty API"
-                            " response on presets update",
+                            " response on presets update"
                         )
-                        raise WLEDEmptyResponseError(msg)
+                        raise WLEDEmptyResponseError(
+                            msg, method="GET", path="/presets.json"
+                        )
                     message_data["presets"] = presets
 
                 device = self._device.update_from_dict(data=message_data)
@@ -232,7 +238,9 @@ class WLED:
                             "Received an invalid JSON error response "
                             f"from request: {method} {uri}"
                         )
-                        raise WLEDInvalidResponseError(msg) from exception
+                        raise WLEDInvalidResponseError(
+                            msg, method=method, path=uri
+                        ) from exception
                     raise WLEDError(response.status, error_body)
                 try:
                     message = contents.decode("utf-8")
@@ -241,7 +249,9 @@ class WLED:
                         "Received a non-UTF-8 error response "
                         f"from request: {method} {uri}"
                     )
-                    raise WLEDInvalidResponseError(msg) from exception
+                    raise WLEDInvalidResponseError(
+                        msg, method=method, path=uri
+                    ) from exception
                 raise WLEDError(
                     response.status,
                     {"message": message},
@@ -251,7 +261,9 @@ class WLED:
                 response_data = await response.text()
             except UnicodeDecodeError as exception:
                 msg = f"Received a non-UTF-8 response from request: {method} {uri}"
-                raise WLEDInvalidResponseError(msg) from exception
+                raise WLEDInvalidResponseError(
+                    msg, method=method, path=uri
+                ) from exception
             if "application/json" in content_type:
                 try:
                     response_data = orjson.loads(response_data)
@@ -260,7 +272,9 @@ class WLED:
                         "Received an invalid JSON response "
                         f"from request: {method} {uri}"
                     )
-                    raise WLEDInvalidResponseError(msg) from exception
+                    raise WLEDInvalidResponseError(
+                        msg, method=method, path=uri
+                    ) from exception
         except TimeoutError as exception:
             msg = f"Timeout occurred while connecting to WLED device at {self.host}"
             raise WLEDConnectionTimeoutError(msg) from exception
@@ -297,23 +311,24 @@ class WLED:
         Raises
         ------
             WLEDEmptyResponseError: The WLED device returned an empty response.
+            WLEDInvalidResponseError: The WLED device returned an invalid response.
 
         """
         if not (data := await self.request("/json")):
             msg = (
                 f"WLED device at {self.host} returned an empty API"
-                " response on full update",
+                " response on full update"
             )
-            raise WLEDEmptyResponseError(msg)
+            raise WLEDEmptyResponseError(msg, method="GET", path="/json")
 
         changed, new_version = self._check_presets_changed(data)
         if changed:
             if not (presets := await self.request("/presets.json")):
                 msg = (
                     f"WLED device at {self.host} returned an empty API"
-                    " response on presets update",
+                    " response on presets update"
                 )
-                raise WLEDEmptyResponseError(msg)
+                raise WLEDEmptyResponseError(msg, method="GET", path="/presets.json")
             data["presets"] = presets
 
         if not self._device:

--- a/tests/test_wled.py
+++ b/tests/test_wled.py
@@ -246,8 +246,12 @@ async def test_update_corrupt_presets_response(
         body=body,
         content_type="application/json",
     )
-    with pytest.raises(WLEDInvalidResponseError, match=r"GET /presets\.json"):
+    with pytest.raises(
+        WLEDInvalidResponseError, match=r"GET /presets\.json"
+    ) as exc_info:
         await wled.update()
+    assert exc_info.value.method == "GET"
+    assert exc_info.value.path == "/presets.json"
 
 
 async def test_update_empty_presets_response(
@@ -269,8 +273,10 @@ async def test_update_empty_presets_response(
             content_type="text/plain",
         )
 
-    with pytest.raises(WLEDEmptyResponseError):
+    with pytest.raises(WLEDEmptyResponseError) as exc_info:
         await wled.update()
+    assert exc_info.value.method == "GET"
+    assert exc_info.value.path == "/presets.json"
 
 
 async def test_update_skips_presets_when_unchanged(
@@ -406,8 +412,10 @@ async def test_listen_preset_change_empty_response(
         content_type="text/plain",
     )
 
-    with pytest.raises(WLEDEmptyResponseError):
+    with pytest.raises(WLEDEmptyResponseError) as exc_info:
         await wled.listen(MagicMock())
+    assert exc_info.value.method == "GET"
+    assert exc_info.value.path == "/presets.json"
 
 
 # =========================================================================

--- a/tests/test_wled.py
+++ b/tests/test_wled.py
@@ -20,6 +20,7 @@ from wled.exceptions import (
     WLEDEmptyResponseError,
     WLEDError,
     WLEDInvalidResponseError,
+    WLEDStatusError,
     WLEDUpgradeError,
 )
 from wled.wled import WLEDReleases
@@ -148,6 +149,39 @@ async def test_http_error(
 
     with pytest.raises(WLEDError):
         assert await wled.request("/")
+
+
+@pytest.mark.parametrize(
+    ("status", "body", "content_type", "expected_body"),
+    [
+        (404, "Not Found", "text/plain", {"message": "Not Found"}),
+        (500, '{"error":"oops"}', "application/json", {"error": "oops"}),
+    ],
+    ids=["404-text", "500-json"],
+)
+async def test_http_error_raises_status_error(  # noqa: PLR0913  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    responses: aioresponses,
+    wled: WLED,
+    status: int,
+    body: str,
+    content_type: str,
+    expected_body: dict,
+) -> None:
+    """Test HTTP error raises WLEDStatusError with structured attributes."""
+    responses.get(
+        "http://example.com/json",
+        status=status,
+        body=body,
+        content_type=content_type,
+    )
+    with pytest.raises(WLEDStatusError) as exc_info:
+        await wled.request("/json")
+    err = exc_info.value
+    assert err.method == "GET"
+    assert err.path == "/json"
+    assert err.status == status
+    assert err.body == expected_body
+    assert err.args == (status, expected_body)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

This PR improves the exception hierarchy in the WLED library to allow consumers (e.g. Home Assistant) to distinguish *which endpoint* failed without fragile string matching on exception messages.

### Motivation

Home Assistant's WLED integration was doing (PR: https://github.com/home-assistant/core/pull/171646 ):

```python
except (WLEDInvalidResponseError, WLEDEmptyResponseError) as er:
    if "presets" in str(er):
        errors["base"] = "invalid_response_presets"
    else:
        errors["base"] = "invalid_response"
```

A reviewer correctly noted that parsing exception message strings is fragile. This PR moves that distinction into the library.

---

## Exception hierarchy

### Before

```
WLEDError
├── WLEDEmptyResponseError   ← inherited from bare Exception (bug)
├── WLEDInvalidResponseError
├── WLEDConnectionError
│   ├── WLEDConnectionTimeoutError
│   └── WLEDConnectionClosedError
├── WLEDUnsupportedVersionError
└── WLEDUpgradeError
```

### After

```
WLEDError
├── WLEDConnectionError
│   ├── WLEDConnectionTimeoutError
│   └── WLEDConnectionClosedError
├── WLEDStatusError              ← NEW: HTTP 4xx/5xx responses
├── WLEDResponseError            ← NEW: base for 2xx responses with unusable body
│   ├── WLEDEmptyResponseError   ← moved under WLEDResponseError
│   └── WLEDInvalidResponseError ← moved under WLEDResponseError
├── WLEDUnsupportedVersionError
└── WLEDUpgradeError
```

**Why this separation?**

`WLEDStatusError` and `WLEDResponseError` represent fundamentally different failure modes:

- `WLEDStatusError` — the device explicitly said *"no"* (returned a 4xx/5xx HTTP status). This is an HTTP-level error. It carries `.status` (int) and `.body` so consumers can inspect what the device reported.
- `WLEDResponseError` — the device said *"ok"* (2xx), but the body is unusable. There are two sub-cases: empty body (`WLEDEmptyResponseError`) and unparseable body (`WLEDInvalidResponseError`). These can be caught together since HA treats them identically — both mean "response body can't be used."

There is no practical use case for catching all three in one handler, so grouping them under a single base would be misleading. Keeping `WLEDStatusError` as a direct child of `WLEDError` makes the distinction explicit.

---

## Changes in detail

### `src/wled/exceptions.py`

- `WLEDEmptyResponseError` fixed to inherit from `WLEDError` (was incorrectly inheriting from bare `Exception`)
- New `WLEDResponseError(WLEDError)` base class with `.method` and `.path` keyword-only attributes; `WLEDEmptyResponseError` and `WLEDInvalidResponseError` now inherit from it
- New `WLEDStatusError(WLEDError)` for HTTP 4xx/5xx responses, with `.method`, `.path`, `.status`, `.body` attributes
- All custom `__init__` use `*args` forwarded to `super().__init__(*args)` to preserve the full backward-compatible positional-argument contract of `Exception`

### `src/wled/wled.py`

- `request()` now raises `WLEDStatusError` (with `method`, `path`, `status`, `body`) instead of bare `WLEDError(response.status, body)` for 4xx/5xx responses
- `WLEDInvalidResponseError` and `WLEDEmptyResponseError` raised with `method=` and `path=` so callers can inspect which endpoint failed
- Fixed accidental tuple construction in error message strings (trailing comma bug in `update()` and `listen()`)
- Updated docstrings for `update()` and `listen()` to document additional raised exceptions

### `src/wled/__init__.py`

- Exports `WLEDResponseError` and `WLEDStatusError`

### `tests/test_wled.py`

- Assertions on `.method` and `.path` added to preset-related error tests

---

## After this PR, HA can replace

```python
except (WLEDInvalidResponseError, WLEDEmptyResponseError) as er:
    if "presets" in str(er):
        errors["base"] = "invalid_response_presets"
    else:
        errors["base"] = "invalid_response"
```

with:

```python
except (WLEDInvalidResponseError, WLEDEmptyResponseError) as er:
    if er.path == "/presets.json":
        errors["base"] = "invalid_response_presets"
    else:
        errors["base"] = "invalid_response"
```

## Test plan

- [x] `pytest tests/` — all 222 tests pass
- [x] Backward compatible: existing code that catches `WLEDInvalidResponseError`, `WLEDEmptyResponseError`, or `WLEDError` continues to work
- [x] `WLEDEmptyResponseError` retry backoff in `update()` still works (inherits from `WLEDResponseError` → `WLEDError`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `WLEDResponseError` and `WLEDStatusError` exception types for more granular error handling.
  * Exception instances now capture HTTP method, path, status code, and response body for improved debugging.

* **Tests**
  * Added comprehensive test coverage for new exception types and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->